### PR TITLE
Copy logic from preflight necessary to iterate all scripts in the postfl...

### DIFF
--- a/assets/client_installer/postflight
+++ b/assets/client_installer/postflight
@@ -7,6 +7,7 @@ from munkilib import reportcommon
 from munkilib import FoundationPlist
 import hashlib
 import sys
+import os
 
 def main():
     '''Main'''
@@ -37,6 +38,50 @@ def main():
         items[key] = {'path':val}
         
     reportcommon.process(serial, items)    
+
+   # define path to directory with postflight scripts
+    scriptdir = os.path.realpath(os.path.dirname(sys.argv[0]))
+    postflightscriptdir = os.path.join(scriptdir, "postflight.d")
+
+    if os.path.exists(postflightscriptdir):
+        from munkilib import utils
+        # Get all files in postflight.d
+        files = os.listdir(postflightscriptdir)
+
+        # Sort list
+        files.sort()
+        for postflightscript in files:
+            if postflightscript.startswith('.'):
+                # Skip files that start with a period
+                continue
+            postflightscriptpath = os.path.join(
+                postflightscriptdir, postflightscript)
+            if os.path.isdir(postflightscriptpath):
+                # Skip directories in postflight.d directory
+                continue
+            try:
+                # Attempt to execute script
+                print 'Running %s' % postflightscript
+                result, stdout, stderr = utils.runExternalScript(
+                    postflightscriptpath, allow_insecure=False, script_args=[runtype])
+                if stdout:
+                        print(stdout.encode('UTF-8'))
+                if stderr:
+                    print('%s Error: %s'
+                        % (postflightscript, stderr))
+                if result:
+                    print('postflight.d/%s return code: %d'
+                                            % (postflightscript, result))
+                    exit(-1)
+
+            except utils.ScriptNotFoundError:
+                pass  # Script has disappeared? Well, it is not required, so pass
+            except utils.RunExternalScriptError, e:
+                print >> sys.stderr, str(e)
+                # Skip this script
+    else:
+        # /usr/local/munki/postflight.d does not exist
+        pass
 
     exit(0)
 


### PR DESCRIPTION
I like having the ability to throw a script into the preflight.d or postflight.d folder when necessary. The preflight script already provided support for running everything in the preflight.d folder, but the postflight script was lacking this functionality.

I copied the functionality over to the postflight script and removed any functions that were specific to the preflight script. I've tested this change and it works as expected. Let me know if you require any other changes to this. (Or if this is functionality you do not want, that is fine as well).
