### PR TITLE
Add a CACHEDIR variable to the installer, such that MUNKIDIR can be safely customized

### DIFF
--- a/app/modules/bluetooth/scripts/install.sh
+++ b/app/modules/bluetooth/scripts/install.sh
@@ -12,7 +12,7 @@ if [ $? = 0 ]; then
 	chmod a+x "${MUNKIPATH}preflight.d/bluetooth.sh"
 
 	# Set preference to include this file in the preflight check
-	defaults write "${PREFPATH}" ReportItems -dict-add bluetooth "${MUNKIPATH}preflight.d/cache/bluetoothinfo.txt"
+	defaults write "${PREFPATH}" ReportItems -dict-add bluetooth "${CACHEPATH}bluetoothinfo.txt"
 
 else
 	echo "Failed to download all required components!"

--- a/app/modules/bluetooth/scripts/uninstall.sh
+++ b/app/modules/bluetooth/scripts/uninstall.sh
@@ -4,4 +4,4 @@
 rm -f "${MUNKIPATH}preflight.d/bluetooth.sh"
 
 # Remove bluetoothinfo.txt file
-rm -f "${MUNKIPATH}preflight.d/cache/bluetoothinfo.txt"
+rm -f "${CACHEPATH}bluetoothinfo.txt"

--- a/app/modules/directory_service/scripts/install.sh
+++ b/app/modules/directory_service/scripts/install.sh
@@ -12,7 +12,7 @@ if [ $? = 0 ]; then
 	chmod a+x "${MUNKIPATH}preflight.d/directoryservice.sh"
 
 	# Set preference to include this file in the preflight check
-	defaults write "${PREFPATH}" ReportItems -dict-add directory_service "${MUNKIPATH}preflight.d/cache/directoryservice.txt"
+	defaults write "${PREFPATH}" ReportItems -dict-add directory_service "${CACHEPATH}directoryservice.txt"
 
 else
 	echo "Failed to download all required components!"

--- a/app/modules/directory_service/scripts/uninstall.sh
+++ b/app/modules/directory_service/scripts/uninstall.sh
@@ -4,5 +4,5 @@
 rm -f "${MUNKIPATH}preflight.d/directoryservice.sh"
 
 # Remove directoryservice.txt
-rm -f "${MUNKIPATH}preflight.d/cache/directoryservice.txt"
+rm -f "${CACHEPATH}directoryservice.txt"
 

--- a/app/modules/disk_report/scripts/install.sh
+++ b/app/modules/disk_report/scripts/install.sh
@@ -12,7 +12,7 @@ if [ $? = 0 ]; then
 	chmod a+x "${MUNKIPATH}preflight.d/disk_info"
 
 	# Set preference to include this file in the preflight check
-	defaults write "${PREFPATH}" ReportItems -dict-add disk_report "${MUNKIPATH}preflight.d/cache/disk.plist"
+	defaults write "${PREFPATH}" ReportItems -dict-add disk_report "${CACHEPATH}disk.plist"
 
 else
 	echo "Failed to download all required components!"

--- a/app/modules/disk_report/scripts/uninstall.sh
+++ b/app/modules/disk_report/scripts/uninstall.sh
@@ -4,5 +4,5 @@
 rm -f "${MUNKIPATH}preflight.d/disk_info"
 
 # Remove disk.plist
-rm -f "${MUNKIPATH}preflight.d/cache/disk.plist"
+rm -f "${CACHEPATH}disk.plist"
 

--- a/app/modules/displays_info/scripts/install.sh
+++ b/app/modules/displays_info/scripts/install.sh
@@ -12,7 +12,7 @@ if [ $? = 0 ]; then
 	chmod a+x "${MUNKIPATH}preflight.d/displays.py"
 
 	# Set preference to include this file in the preflight check
-	defaults write "${PREFPATH}" ReportItems -dict-add displays_info "${MUNKIPATH}preflight.d/cache/displays.txt"
+	defaults write "${PREFPATH}" ReportItems -dict-add displays_info "${CACHEPATH}displays.txt"
 
 else
 	echo "Failed to download all required components!"

--- a/app/modules/displays_info/scripts/uninstall.sh
+++ b/app/modules/displays_info/scripts/uninstall.sh
@@ -4,4 +4,4 @@
 rm -f "${MUNKIPATH}preflight.d/displays.py"
 
 # Remove directoryservice.txt
-rm -f "${MUNKIPATH}preflight.d/cache/displays.txt"
+rm -f "${CACHEPATH}displays.txt"

--- a/app/modules/filevault_status/scripts/install.sh
+++ b/app/modules/filevault_status/scripts/install.sh
@@ -16,7 +16,7 @@ if [ $? = 0 ]; then
 	chmod a+x /usr/local/bin/filevault_2_status_check.sh "${MUNKIPATH}preflight.d/filevaultstatus"
 
 	# Set preference to include this file in the preflight check
-	defaults write "${PREFPATH}" ReportItems -dict-add filevault_status "${MUNKIPATH}preflight.d/cache/filevaultstatus.txt"
+	defaults write "${PREFPATH}" ReportItems -dict-add filevault_status "${CACHEPATH}filevaultstatus.txt"
 else
 	echo "! Failed to install all required components"
 	echo "! Skipping filevault status report"

--- a/app/modules/filevault_status/scripts/uninstall.sh
+++ b/app/modules/filevault_status/scripts/uninstall.sh
@@ -4,7 +4,7 @@
 rm -f "${MUNKIPATH}preflight.d/filevaultstatus"
 
 # Remove the filevaultstatus.txt cache file
-rm -f "${MUNKIPATH}preflight.d/cache/filevaultstatus.txt"
+rm -f "${CACHEPATH}filevaultstatus.txt"
 
 # We'll leave the check script alone
 # rm -f /usr/local/bin/filevault_2_status_check.sh

--- a/app/modules/localadmin/scripts/install.sh
+++ b/app/modules/localadmin/scripts/install.sh
@@ -12,7 +12,7 @@ if [ $? = 0 ]; then
 	chmod a+x "${MUNKIPATH}preflight.d/localadmin"
 
 	# Set preference to include this file in the preflight check
-	defaults write "${PREFPATH}" ReportItems -dict-add localadmin "${MUNKIPATH}preflight.d/cache/localadmins.txt"
+	defaults write "${PREFPATH}" ReportItems -dict-add localadmin "${CACHEPATH}localadmins.txt"
 
 else
 	echo "Failed to download all required components!"

--- a/app/modules/localadmin/scripts/uninstall.sh
+++ b/app/modules/localadmin/scripts/uninstall.sh
@@ -4,4 +4,4 @@
 rm -f "${MUNKIPATH}preflight.d/localadmin"
 
 # Remove localadmins.txt file
-rm -f "${MUNKIPATH}preflight.d/cache/localadmins.txt"
+rm -f "${CACHEPATH}localadmins.txt"

--- a/app/modules/network/scripts/install.sh
+++ b/app/modules/network/scripts/install.sh
@@ -17,4 +17,4 @@ fi
 chmod a+x "${MUNKIPATH}preflight.d/networkinfo.sh"
 
 # Set preference to include this file in the preflight check
-defaults write "${PREFPATH}" ReportItems -dict-add network "${MUNKIPATH}preflight.d/cache/networkinfo.txt"
+defaults write "${PREFPATH}" ReportItems -dict-add network "${CACHEPATH}networkinfo.txt"

--- a/app/modules/network/scripts/uninstall.sh
+++ b/app/modules/network/scripts/uninstall.sh
@@ -4,5 +4,5 @@
 rm -f "${MUNKIPATH}preflight.d/networkinfo.sh"
 
 # Remove networkinfo.txt
-rm -f "${MUNKIPATH}preflight.d/cache/networkinfo.txt"
+rm -f "${CACHEPATH}networkinfo.txt"
 

--- a/app/modules/warranty/scripts/install.sh
+++ b/app/modules/warranty/scripts/install.sh
@@ -12,7 +12,7 @@ if [ $? = 0 ]; then
 	chmod a+x "${MUNKIPATH}preflight.d/warranty"
 
 	# Set preference to include this file in the preflight check
-	defaults write "${PREFPATH}" ReportItems -dict-add warranty "${MUNKIPATH}preflight.d/cache/warranty.txt"
+	defaults write "${PREFPATH}" ReportItems -dict-add warranty "${CACHEPATH}warranty.txt"
 
 else
 	echo "Failed to download all required components!"

--- a/app/modules/warranty/scripts/uninstall.sh
+++ b/app/modules/warranty/scripts/uninstall.sh
@@ -4,4 +4,4 @@
 rm -f "${MUNKIPATH}preflight.d/warranty"
 
 # Remove warranty.txt file
-rm -f "${MUNKIPATH}preflight.d/cache/warranty.txt"
+rm -f "${CACHEPATH}warranty.txt"

--- a/app/views/install/install_script.php
+++ b/app/views/install/install_script.php
@@ -7,6 +7,7 @@ BASEURL="<?php echo
 	. conf('subdirectory'); ?>"
 TPL_BASE="${BASEURL}/assets/client_installer/"
 MUNKIPATH="/usr/local/munki/" # TODO read munkipath from munki config
+CACHEPATH="${MUNKIPATH}preflight.d/cache/"
 PREFPATH="/Library/Preferences/MunkiReport"
 CURL="/usr/bin/curl --insecure --fail --silent  --show-error"
 # Exit status


### PR DESCRIPTION
PR applies to issue #180

Currently when manually customizing the `MUNKIDIR` variable in the generated installer script, the custom path will also end up in the preferences file. Introduce `CACHEPATH`, such that `MUNKIDIR` can be set to a temporary directory for packaging purposes.
