### PR TITLE
Add TLSv1 support for URLLIB2

### DIFF
--- a/assets/client_installer/reportcommon
+++ b/assets/client_installer/reportcommon
@@ -8,6 +8,9 @@ import pwd
 import sys
 import urllib
 import urllib2
+import httplib
+import socket
+import ssl
 from Foundation import NSArray, NSDate, NSMetadataQuery, NSPredicate
 from Foundation import CFPreferencesAppSynchronize
 from Foundation import CFPreferencesCopyAppValue
@@ -20,6 +23,39 @@ import ctypes
 import struct
 import time
 import os
+
+class TLS1Connection(httplib.HTTPSConnection):
+    """Like HTTPSConnection but more specific"""
+    def __init__(self, host, **kwargs):
+        httplib.HTTPSConnection.__init__(self, host, **kwargs)
+ 
+    def connect(self):
+        """Overrides HTTPSConnection.connect to specify TLS version"""
+        # Standard implementation from HTTPSConnection, which is not
+        # designed for extension, unfortunately
+        sock = socket.create_connection((self.host, self.port),
+                self.timeout, self.source_address)
+        if getattr(self, '_tunnel_host', None):
+            self.sock = sock
+            self._tunnel()
+ 
+        # This is the only difference; default wrap_socket uses SSLv23
+        self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file,
+                ssl_version=ssl.PROTOCOL_TLSv1)
+ 
+class TLS1Handler(urllib2.HTTPSHandler):
+    """Like HTTPSHandler but more specific"""
+    def __init__(self):
+        urllib2.HTTPSHandler.__init__(self)
+ 
+    def https_open(self, req):
+        return self.do_open(TLS1Connection, req)
+
+TLS = True
+
+if TLS is True:
+    # Override default handler
+    urllib2.install_opener(urllib2.build_opener(TLS1Handler()))
 
 # our preferences "bundle_id"
 BUNDLE_ID = 'MunkiReport'


### PR DESCRIPTION
This fix will allow MunkiReport-PHP when running on either OS X 10.10
Server or a newer version of Apache to use TLSv1 as the default
protocol when submitting data as Python by default uses SSL. Thanks to
https://gist.github.com/flandr/74be22d1c3d7c1dfefdd for the fix.