### PR TITLE
Additional HTTP Headers/Basic Auth Support for install & submit

### DIFF
--- a/app/modules/bluetooth/scripts/install.sh
+++ b/app/modules/bluetooth/scripts/install.sh
@@ -4,7 +4,7 @@
 CTL="${BASEURL}index.php?/module/bluetooth/"
 
 # Get the scripts in the proper directories
-${CURL} "${CTL}get_script/bluetooth.sh" -o "${MUNKIPATH}preflight.d/bluetooth.sh"
+"${CURL[@]}" "${CTL}get_script/bluetooth.sh" -o "${MUNKIPATH}preflight.d/bluetooth.sh"
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/app/modules/directory_service/scripts/install.sh
+++ b/app/modules/directory_service/scripts/install.sh
@@ -4,7 +4,7 @@
 CTL="${BASEURL}index.php?/module/directory_service/"
 
 # Get the scripts in the proper directories
-${CURL} "${CTL}get_script/directoryservice.sh" -o "${MUNKIPATH}preflight.d/directoryservice.sh"
+"${CURL[@]}" "${CTL}get_script/directoryservice.sh" -o "${MUNKIPATH}preflight.d/directoryservice.sh"
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/app/modules/disk_report/scripts/install.sh
+++ b/app/modules/disk_report/scripts/install.sh
@@ -4,7 +4,7 @@
 DR_CTL="${BASEURL}index.php?/module/disk_report/"
 
 # Get the scripts in the proper directories
-${CURL} "${DR_CTL}get_script/disk_info" -o "${MUNKIPATH}preflight.d/disk_info"
+"${CURL[@]}" "${DR_CTL}get_script/disk_info" -o "${MUNKIPATH}preflight.d/disk_info"
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/app/modules/displays_info/scripts/install.sh
+++ b/app/modules/displays_info/scripts/install.sh
@@ -4,7 +4,7 @@
 CTL="${BASEURL}index.php?/module/displays_info/"
 
 # Get the scripts in the proper directories
-${CURL} "${CTL}get_script/displays.py" -o "${MUNKIPATH}preflight.d/displays.py"
+"${CURL[@]}" "${CTL}get_script/displays.py" -o "${MUNKIPATH}preflight.d/displays.py"
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/app/modules/filevault_status/scripts/install.sh
+++ b/app/modules/filevault_status/scripts/install.sh
@@ -7,8 +7,8 @@ FV_CTL="${BASEURL}index.php?/module/filevault_status/"
 mkdir -p /usr/local/bin || ERR=1
 
 # Get the scripts in the proper directories
-${CURL}  "${FV_CTL}get_script/filevault_2_status_check.sh" -o "/usr/local/bin/filevault_2_status_check.sh" \
-	&& ${CURL}  "${FV_CTL}get_script/filevaultstatus" -o "${MUNKIPATH}preflight.d/filevaultstatus" \
+"${CURL[@]}"  "${FV_CTL}get_script/filevault_2_status_check.sh" -o "/usr/local/bin/filevault_2_status_check.sh" \
+	&& "${CURL[@]}"  "${FV_CTL}get_script/filevaultstatus" -o "${MUNKIPATH}preflight.d/filevaultstatus" \
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/app/modules/inventory/scripts/install.sh
+++ b/app/modules/inventory/scripts/install.sh
@@ -4,7 +4,7 @@
 DR_CTL="${BASEURL}index.php?/module/inventory/"
 
 # Get the scripts in the proper directories
-${CURL} "${DR_CTL}get_script/inventory_add_plugins" -o "${MUNKIPATH}postflight.d/inventory_add_plugins.py"
+"${CURL[@]}" "${DR_CTL}get_script/inventory_add_plugins" -o "${MUNKIPATH}postflight.d/inventory_add_plugins.py"
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/app/modules/localadmin/scripts/install.sh
+++ b/app/modules/localadmin/scripts/install.sh
@@ -4,7 +4,7 @@
 CTL="${BASEURL}index.php?/module/localadmin/"
 
 # Get the scripts in the proper directories
-${CURL} "${CTL}get_script/localadmin" -o "${MUNKIPATH}preflight.d/localadmin"
+"${CURL[@]}" "${CTL}get_script/localadmin" -o "${MUNKIPATH}preflight.d/localadmin"
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/app/modules/network/scripts/install.sh
+++ b/app/modules/network/scripts/install.sh
@@ -4,7 +4,7 @@
 NW_CTL="${BASEURL}index.php?/module/network/"
 
 # Get the script in the proper directory
-${CURL} "${NW_CTL}get_script/networkinfo.sh" -o "${MUNKIPATH}preflight.d/networkinfo.sh"
+"${CURL[@]}" "${NW_CTL}get_script/networkinfo.sh" -o "${MUNKIPATH}preflight.d/networkinfo.sh"
 
 if [ "${?}" != 0 ]
 then

--- a/app/modules/warranty/scripts/install.sh
+++ b/app/modules/warranty/scripts/install.sh
@@ -4,7 +4,7 @@
 CTL="${BASEURL}index.php?/module/warranty/"
 
 # Get the scripts in the proper directories
-${CURL} "${CTL}get_script/warranty" -o "${MUNKIPATH}preflight.d/warranty"
+"${CURL[@]}" "${CTL}get_script/warranty" -o "${MUNKIPATH}preflight.d/warranty"
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/app/views/install/install_script.php
+++ b/app/views/install/install_script.php
@@ -47,7 +47,7 @@ chmod a+x "${MUNKIPATH}"{preflight,postflight,report_broken_client}
 # Create preflight.d + download scripts
 mkdir -p "${MUNKIPATH}preflight.d"
 cd "${MUNKIPATH}preflight.d"
-${CURL[@]} "${TPL_BASE}submit.preflight" --remote-name
+"${CURL[@]}" "${TPL_BASE}submit.preflight" --remote-name
 
 if [ "${?}" != 0 ]
 then

--- a/app/views/install/install_script.php
+++ b/app/views/install/install_script.php
@@ -13,8 +13,8 @@ ERR=0
 VERSION="<?=get_version()?>"
 
 # build additional HTTP headers
+PREFPATH="/Library/Preferences/MunkiReport"
 if [ "$(defaults read "${PREFPATH}" UseMunkiAdditionalHttpHeaders)" = "1" ]; then
-	PREFPATH="/Library/Preferences/MunkiReport"
 	BUNDLE_ID='ManagedInstalls'
 	MANAGED_INSTALLS_PLIST_PATHS=("/private/var/root/Library/Preferences/${BUNDLE_ID}.plist" "/Library/Preferences/${BUNDLE_ID}.plist")
 	ADDITIONAL_HTTP_HEADERS_KEY='AdditionalHttpHeaders'

--- a/app/views/install/install_script.php
+++ b/app/views/install/install_script.php
@@ -8,7 +8,18 @@ BASEURL="<?php echo
 TPL_BASE="${BASEURL}/assets/client_installer/"
 MUNKIPATH="/usr/local/munki/" # TODO read munkipath from munki config
 PREFPATH="/Library/Preferences/MunkiReport"
-CURL="/usr/bin/curl --insecure --fail --silent  --show-error"
+BUNDLE_ID='ManagedInstalls'
+MANAGED_INSTALLS_PLIST_PATHS=("/private/var/root/Library/Preferences/${BUNDLE_ID}.plist" "/Library/Preferences/${BUNDLE_ID}.plist")
+ADDITIONAL_HTTP_HEADERS_KEY='AdditionalHttpHeaders'
+ADDITIONAL_HTTP_HEADERS=()
+for plist in "${MANAGED_INSTALLS_PLIST_PATHS[@]}"; do
+	while IFS= read -r line; do
+		if [[ "$line" =~ ^[^()]+$ ]]; then
+			ADDITIONAL_HTTP_HEADERS+=("$line")
+		fi
+	done <<< "$(defaults read "${MANAGED_INSTALLS_PLIST_PATHS%.plist}" "$ADDITIONAL_HTTP_HEADERS_KEY")"
+done
+CURL="/usr/bin/curl --insecure --fail --silent  --show-error $(for header in "${ADDITIONAL_HTTP_HEADERS[@]}"; do echo -n "-H $header "; done)"
 # Exit status
 ERR=0
 VERSION="<?=get_version()?>"

--- a/app/views/install/install_script.php
+++ b/app/views/install/install_script.php
@@ -17,7 +17,7 @@ for plist in "${MANAGED_INSTALLS_PLIST_PATHS[@]}"; do
 		if [[ "$line" =~ ^[^()]+$ ]]; then
 			ADDITIONAL_HTTP_HEADERS+=("$line")
 		fi
-	done <<< "$(defaults read "${MANAGED_INSTALLS_PLIST_PATHS%.plist}" "$ADDITIONAL_HTTP_HEADERS_KEY")"
+	done <<< "$(defaults read "${plist%.plist}" "$ADDITIONAL_HTTP_HEADERS_KEY")"
 done
 CURL="/usr/bin/curl --insecure --fail --silent  --show-error $(for header in "${ADDITIONAL_HTTP_HEADERS[@]}"; do echo -n "-H $header "; done)"
 # Exit status

--- a/app/views/install/install_script.php
+++ b/app/views/install/install_script.php
@@ -47,7 +47,7 @@ chmod a+x "${MUNKIPATH}"{preflight,postflight,report_broken_client}
 # Create preflight.d + download scripts
 mkdir -p "${MUNKIPATH}preflight.d"
 cd "${MUNKIPATH}preflight.d"
-${CURL} "${TPL_BASE}submit.preflight" --remote-name
+${CURL[@]} "${TPL_BASE}submit.preflight" --remote-name
 
 if [ "${?}" != 0 ]
 then

--- a/assets/client_installer/reportcommon
+++ b/assets/client_installer/reportcommon
@@ -20,6 +20,7 @@ import ctypes
 import struct
 import time
 import os
+import re
 
 # our preferences "bundle_id"
 BUNDLE_ID = 'MunkiReport'
@@ -49,7 +50,12 @@ def display_detail(msg, *args):
     munkicommon.display_detail('Munkireport: %s' % msg, *args)
 
 def curl(url, values):
+    custom_headers = munkicommon.pref(munkicommon.ADDITIONAL_HTTP_HEADERS_KEY)
     req = urllib2.Request(url, urllib.urlencode(values))
+    for header in custom_headers:
+        m = re.search(r'^(?P<header_name>.*?): (?P<header_value>.*?)$', header)
+        if m:
+            req.add_header(m.group('header_name'), m.group('header_value'))
     try:
         response = urllib2.urlopen(req)
     except urllib2.URLError, e:

--- a/assets/client_installer/reportcommon
+++ b/assets/client_installer/reportcommon
@@ -50,12 +50,13 @@ def display_detail(msg, *args):
     munkicommon.display_detail('Munkireport: %s' % msg, *args)
 
 def curl(url, values):
-    custom_headers = munkicommon.pref(munkicommon.ADDITIONAL_HTTP_HEADERS_KEY)
     req = urllib2.Request(url, urllib.urlencode(values))
-    for header in custom_headers:
-        m = re.search(r'^(?P<header_name>.*?): (?P<header_value>.*?)$', header)
-        if m:
-            req.add_header(m.group('header_name'), m.group('header_value'))
+    if pref('UseMunkiAdditionalHttpHeaders'):
+        custom_headers = munkicommon.pref(munkicommon.ADDITIONAL_HTTP_HEADERS_KEY)
+        for header in custom_headers:
+            m = re.search(r'^(?P<header_name>.*?): (?P<header_value>.*?)$', header)
+            if m:
+                req.add_header(m.group('header_name'), m.group('header_value'))
     try:
         response = urllib2.urlopen(req)
     except urllib2.URLError, e:


### PR DESCRIPTION
These updates support additional HTTP headers during both installation & submit (pulled from the Munki configs... either `/Library/Preferences/ManagedInstalls.plist` or `/private/var/root/Library/Preferences/ManagedInstalls.plist`). This is useful if you have additional headers you want or need to send, esp. if you're using [HTTP Basic Auth](https://github.com/munki/munki/wiki/Using-Basic-Authentication) and have Munki & MunkiReport running on the same server (since OS X 10.9 Mavericks and newer only support a single realm for an entire site, unless you're splitting up Munki & MunkiReport to different subdomains or want to significantly modify your Apache configs).

If installing from a server that requires HTTP Basic auth, you may want to run the installer as follows:

    bash-3.2$ sudo /bin/bash -c "$(curl -s -H "Authorization: Basic INSERT_AUTH_HASH_HERE" https://example.com/index.php?/install
