### PR TITLE
Add temperature_unit processing to the client tab

### DIFF
--- a/app/views/client/power_tab.php
+++ b/app/views/client/power_tab.php
@@ -42,7 +42,21 @@ $power = new power_model($serial_number);
 				</tr>
 					<tr>
 					<td>Temperature:</td>
-					<td><?=$power->temperature?></td>
+					<td><?php
+						if ($power->temperature == 0 || $power->temperature == ""){
+							echo "";
+							}
+						else {
+							if (conf('temperature_unit') == "F"){
+								// Fahrenheit
+								echo round(((($power->temperature * 9/5 ) + 3200 ) / 100), 2) . "° F";
+								}
+							else {
+								// Celsius
+								echo $power->temperature = ($power->temperature / 100) . "° C";
+								}
+						}
+						?></td>
 				</tr>
 					<tr>
 					<td>Condition:</td>


### PR DESCRIPTION
While testing the recently added power module (which is awesome, by the way!), I noticed that the temperature was just being pulled as a raw int from the database onto that page, leading to ugly temperature display. I poached the conversions from elsewhere and included logic to not display the temperature at all if no value is present.

Only question / todo - would it be preferable to put the temperature label in the left column to match the ones above it (e.g. mAh), or is the right column ok?