### PR TITLE
Make managed installs list sortable

### DIFF
--- a/app/views/client/munki_tab.php
+++ b/app/views/client/munki_tab.php
@@ -186,7 +186,7 @@ if(isset($report['ItemsToRemove']))
 		  <h2><?php echo $title; ?></h2>
 
 			<?php if(isset($report[$report_key]) && $report[$report_key]): ?>
-			<table class="table table-striped">
+			<table class="table table-striped <?php echo $report_key; ?>">
 		      <thead>
 		        <tr>
 		          <th>Name</th>
@@ -242,3 +242,13 @@ if(isset($report['ItemsToRemove']))
   </div><!-- </div class="row"> -->
 
 <pre><?php //print_r($client->rs) ?></pre>
+<script>
+  $(document).on('appReady', function(e, lang) {
+
+        // Initialize datatables
+            $('.ManagedInstalls').dataTable({
+                "bServerSide": false,
+                "order": [0,'asc']
+            });
+  });
+</script>


### PR DESCRIPTION
The managed installs list table on the managed software tab is now
sortable using dataTables. Enhancement Request #178. Thanks for bearing with me on the pull requests and sorry I am such a gitiot. 