### PR TITLE
Update widget labels

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -167,9 +167,9 @@
 		"power": {
 			"missing": "Missing",
 			"normal": "Normal",
-			"now": "Now",
-			"service": "Service",
-			"soon": "Soon"
+			"now": "Replace Now",
+			"service": "Service Now",
+			"soon": "Service Soon"
 		}
 	}
 }


### PR DESCRIPTION
I didn't find the battery widget labels to be very intuitive - here are my suggestions for new ones. If those don't work, maybe a tooltip with the full text and a short explanation of what each status might mean?

(updated with correct file for localization!)