### PR TITLE
Wip - edited output of widgets to be more consistent

### DIFF
--- a/app/views/widgets/bound_to_ds_widget.php
+++ b/app/views/widgets/bound_to_ds_widget.php
@@ -20,13 +20,13 @@
 				$obj = current($queryobj->query($sql));
 				?>
 				<?php if($obj): ?>
-				<a href="<?php echo url('show/listing/directoryservice'); ?>" class="btn btn-success">
-					<span class="bigger-150"> <?php echo $obj->arebound; ?> </span><br>
-					<span data-i18n="widget.bound_to_ds.bound"></span>
-				</a>
 				<a href="<?php echo url('show/listing/directoryservice'); ?>" class="btn btn-danger">
 					<span class="bigger-150"> <?php echo $obj->total - $obj->arebound; ?> </span><br>
 					<span data-i18n="widget.bound_to_ds.notbound"></span>
+				</a>
+				<a href="<?php echo url('show/listing/directoryservice'); ?>" class="btn btn-success">
+					<span class="bigger-150"> <?php echo $obj->arebound; ?> </span><br>
+					<span data-i18n="widget.bound_to_ds.bound"></span>
 				</a>
 				<?php endif; ?>
 

--- a/app/views/widgets/client_widget.php
+++ b/app/views/widgets/client_widget.php
@@ -76,21 +76,21 @@ $obj = current($queryobj->query($sql));
 
 					
                                 <?php if($obj): ?>
-                                        <a href="<?php echo url('show/listing/clients'); ?>" class="btn btn-danger">
-                                                <span class="bigger-150"> <?php echo $obj->inactive_three_month; ?> </span>
-                                                <br>
-                                                3 months +
-                                        </a>
-                                        <a href="<?php echo url('show/listing/clients'); ?>" class="btn btn-warning">
-                                                <span class="bigger-150"> <?php echo $obj->inactive_month; ?> </span>
-                                                <br>
-                                                Last mo
-                                        </a>
-                                        <a href="<?php echo url('show/listing/clients'); ?>" class="btn btn-info">
-                                                <span class="bigger-150"> <?php echo $obj->inactive_week; ?> </span>
-                                                <br>
-                                                Last wk
-                                        </a>
+					<a href="<?php echo url('show/listing/clients'); ?>" class="btn btn-danger">
+						<span class="bigger-150"> <?php echo $obj->inactive_three_month; ?> </span>
+						<br>
+						3 months +
+					</a>
+					<a href="<?php echo url('show/listing/clients'); ?>" class="btn btn-warning">
+						<span class="bigger-150"> <?php echo $obj->inactive_month; ?> </span>
+						<br>
+						Last mo
+					</a>
+					<a href="<?php echo url('show/listing/clients'); ?>" class="btn btn-info">
+						<span class="bigger-150"> <?php echo $obj->inactive_week; ?> </span>
+						<br>
+						Last wk
+					</a>
 					
 				<?php endif; ?>
 

--- a/app/views/widgets/client_widget.php
+++ b/app/views/widgets/client_widget.php
@@ -75,23 +75,22 @@ $obj = current($queryobj->query($sql));
 				<div class="panel-body text-center">
 
 					
-				<?php if($obj): ?>
-
-					<a href="<?php echo url('show/listing/clients'); ?>" class="btn btn-info">
-						<span class="bigger-150"> <?php echo $obj->inactive_week; ?> </span>
-						<br>
-						Last wk
-					</a>
-					<a href="<?php echo url('show/listing/clients'); ?>" class="btn btn-warning">
-						<span class="bigger-150"> <?php echo $obj->inactive_month; ?> </span>
-						<br>
-						Last mo
-					</a>
-					<a href="<?php echo url('show/listing/clients'); ?>" class="btn btn-danger">
-						<span class="bigger-150"> <?php echo $obj->inactive_three_month; ?> </span>
-						<br>
-						3 months +
-					</a>
+                                <?php if($obj): ?>
+                                        <a href="<?php echo url('show/listing/clients'); ?>" class="btn btn-danger">
+                                                <span class="bigger-150"> <?php echo $obj->inactive_three_month; ?> </span>
+                                                <br>
+                                                3 months +
+                                        </a>
+                                        <a href="<?php echo url('show/listing/clients'); ?>" class="btn btn-warning">
+                                                <span class="bigger-150"> <?php echo $obj->inactive_month; ?> </span>
+                                                <br>
+                                                Last mo
+                                        </a>
+                                        <a href="<?php echo url('show/listing/clients'); ?>" class="btn btn-info">
+                                                <span class="bigger-150"> <?php echo $obj->inactive_week; ?> </span>
+                                                <br>
+                                                Last wk
+                                        </a>
 					
 				<?php endif; ?>
 

--- a/app/views/widgets/disk_report_widget.php
+++ b/app/views/widgets/disk_report_widget.php
@@ -11,17 +11,17 @@
 				<div class="panel-body text-center">
 
 
-					<a id="disk-success" href="<?php echo url('show/listing/disk#'.rawurlencode('freespace > 10GB')); ?>" class="btn btn-success hide">
+					<a id="disk-danger" href="<?php echo url('show/listing/disk#'.rawurlencode('freespace < 5GB')); ?>" class="btn btn-danger hide">
 						<span class="bigger-150"></span><br>
-						10GB +
+						&lt; 5GB
 					</a>
 					<a id="disk-warning" href="<?php echo url('show/listing/disk#'.rawurlencode('5GB freespace 10GB')); ?>" class="btn btn-warning hide">
 						<span class="bigger-150"></span><br>
 						&lt; 10GB
 					</a>
-					<a id="disk-danger" href="<?php echo url('show/listing/disk#'.rawurlencode('freespace < 5GB')); ?>" class="btn btn-danger hide">
+					<a id="disk-success" href="<?php echo url('show/listing/disk#'.rawurlencode('freespace > 10GB')); ?>" class="btn btn-success hide">
 						<span class="bigger-150"></span><br>
-						&lt; 5GB
+						10GB +
 					</a>
 
                     <span id="disk-nodata" data-i18n="no_clients"></span>

--- a/app/views/widgets/uptime_widget.php
+++ b/app/views/widgets/uptime_widget.php
@@ -48,7 +48,7 @@
 						<span class="bigger-150"> <?php echo $in_green; ?> </span><br>
 						< 1 Day
 					</a>
-					
+	
 				</div>
 
 			</div><!-- /panel -->

--- a/app/views/widgets/uptime_widget.php
+++ b/app/views/widgets/uptime_widget.php
@@ -36,21 +36,19 @@
 
 					?>
 
-					<a href="<?php echo url('show/listing/clients'); ?>" class="btn btn-success">
-						<span class="bigger-150"> <?php echo $in_green; ?> </span><br>
-						< 1 Day
-					</a>
-
-					<a href="<?php echo url('show/listing/clients'); ?>" class="btn btn-warning">
-						<span class="bigger-150"> <?php echo $in_yellow; ?> </span><br>
-						< 7 Days
-					</a>
-
 					<a href="<?php echo url('show/listing/clients'); ?>" class="btn btn-danger">
 						<span class="bigger-150"> <?php echo $in_red; ?> </span><br>
 						7 Days +
 					</a>
-
+					<a href="<?php echo url('show/listing/clients'); ?>" class="btn btn-warning">
+						<span class="bigger-150"> <?php echo $in_yellow; ?> </span><br>
+						< 7 Days
+					</a>
+					<a href="<?php echo url('show/listing/clients'); ?>" class="btn btn-success">
+						<span class="bigger-150"> <?php echo $in_green; ?> </span><br>
+						< 1 Day
+					</a>
+					
 				</div>
 
 			</div><!-- /panel -->


### PR DESCRIPTION
I adjusted some widgets order of output so the dashboard would have a more consistent look to it.  In the default output of some widgets is error->success left to right so the buttons were red/orange/green.  Others output success->error so they were green/orange/red.  My edits make it consistent error->success so buttons are red->green and make a more unified look.  Below are screencaps of the default vs. edited output.

![original](https://cloud.githubusercontent.com/assets/1416288/8805666/18cc7e34-2f98-11e5-87f0-e8b09f39c9fc.png)

![edited](https://cloud.githubusercontent.com/assets/1416288/8805670/1d249296-2f98-11e5-8468-b25dfeb051b0.png)
