### PR TITLE
Fixed servermetrics_model.php 500

### DIFF
--- a/app/modules/servermetrics/servermetrics_model.php
+++ b/app/modules/servermetrics/servermetrics_model.php
@@ -67,7 +67,7 @@ class Servermetrics_model extends Model {
 	 **/
 	function get_data($serial_number, $hours = 24)
 	{
-		$out =[];
+		$out = '';
 
 		if (authorized_for_serial($serial_number))
 		{


### PR DESCRIPTION
Fixed the syntax causing a 500.