### PR TITLE
Add total client count on dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,30 @@
-### 2.5.0 (June 25, 2015)
+### 2.5.3 (July 31, 2015)
 
 FIXES
 
-* 
+* Filesize formatter now uses base 1000 instead of 1024
+* Fix uninstall scripts
+* Session vars are updated when adding/removing machine groups
+* Better support for Corestorage volume reporting
+* Reordered buttons in some widgets thanks to @poundbangbash
+* Servermetrics model
 
 NEW FEATURES
 
-* Business Units
-
-How to upgrade:
-
-* Migrations ON
-* Add authorization
+* Support for Business Units - [Read more](https://github.com/munkireport/munkireport-php/blob/master/docs/business_units.md)
+* Support for Machine Groups - [Read more](https://github.com/munkireport/munkireport-php/blob/master/docs/machine_groups.md)
+* Role Based Access [Read more](https://github.com/munkireport/munkireport-php/blob/master/docs/authorization.md)
+* Filter on Machine Group
+* Server metrics module (reports server metrics for OSX Server)
+* Services module (reports on running services on OSX Server)
+* Timemachine module (reports on Time Machine backups)
+* Certificate module (reports on certificate expiration dates)
+* Comment module (for custom views: add admin comments)
+* Improved Disk reporting (now reports on all connected HFS Disks, reports on RAID and FUSION drives)
+* Live updates on certain widgets
+* German localisation thanks to @fridomac 
+* Reporting on OS Buildversion
+* Disk size thresholds
 
 ### 2.4.2 (April 25, 2015)
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 munkireport
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/app/helpers/site_helper.php
+++ b/app/helpers/site_helper.php
@@ -1,7 +1,7 @@
 <?php
 
 // Munkireport version (last number is number of commits)
-$GLOBALS['version'] = '2.5.2.1362';
+$GLOBALS['version'] = '2.5.3.1365';
 
 // Return version without commit count
 function get_version()

--- a/app/helpers/site_helper.php
+++ b/app/helpers/site_helper.php
@@ -1,7 +1,7 @@
 <?php
 
 // Munkireport version (last number is number of commits)
-$GLOBALS['version'] = '2.5.2.1323';
+$GLOBALS['version'] = '2.5.2.1362';
 
 // Return version without commit count
 function get_version()

--- a/app/helpers/site_helper.php
+++ b/app/helpers/site_helper.php
@@ -1,7 +1,7 @@
 <?php
 
 // Munkireport version (last number is number of commits)
-$GLOBALS['version'] = '2.5.3.1365';
+$GLOBALS['version'] = '2.5.3.1368';
 
 // Return version without commit count
 function get_version()

--- a/app/modules/disk_report/disk_report_controller.php
+++ b/app/modules/disk_report/disk_report_controller.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 /**
  * Disk report controller class
@@ -27,7 +27,7 @@ class Disk_report_controller extends Module_controller
      * Retrieve data in json format
      *
      * @return void
-     * @author 
+     * @author
      **/
     function get_data($serial_number = '')
     {
@@ -51,7 +51,7 @@ class Disk_report_controller extends Module_controller
 	 * Get statistics
 	 *
 	 * @return void
-	 * @author 
+	 * @author
 	 **/
 	function get_stats($mount_point = '/')
 	{
@@ -62,9 +62,16 @@ class Disk_report_controller extends Module_controller
             $obj->view('json', array('msg' => array('error' => 'Not authenticated')));
             return;
         }
+				$disk_report = new Disk_report_model;
+				$out = array();
+				$thresholds = conf('disk_thresholds', array('danger' => 5, 'warning' => 10));
+				$out['thresholds'] = $thresholds;
+				$out['stats'] = $disk_report->get_stats(
+					$mount_point,
+					$thresholds['danger'],
+					$thresholds['warning']);
 
-        $disk_report = new Disk_report_model;
-        $obj->view('json', array('msg' => $disk_report->get_stats($mount_point)));
+        $obj->view('json', array('msg' => $out));
 
 	}
 

--- a/app/modules/servermetrics/servermetrics_model.php
+++ b/app/modules/servermetrics/servermetrics_model.php
@@ -67,7 +67,7 @@ class Servermetrics_model extends Model {
 	 **/
 	function get_data($serial_number, $hours = 24)
 	{
-		$out =[];
+		$out = array();
 
 		if (authorized_for_serial($serial_number))
 		{

--- a/app/modules/servermetrics/servermetrics_model.php
+++ b/app/modules/servermetrics/servermetrics_model.php
@@ -2,7 +2,7 @@
 class Servermetrics_model extends Model {
 
 	// Field order as sent by postflight and served by get_data().
-	var	$keys = [
+	var	$keys = array(
 		'afp_sessions',
 		'smb_sessions',
 		'caching_cache_toclients',
@@ -19,7 +19,7 @@ class Servermetrics_model extends Model {
 		'network_out',
 		'cpu_nice',
 		'memory_inactive'
-	];
+	);
 
 	function __construct($serial='')
 	{

--- a/app/views/widgets/client_widget.php
+++ b/app/views/widgets/client_widget.php
@@ -33,7 +33,12 @@ $obj = current($queryobj->query($sql));
 
 					
 				<?php if($obj): ?>
-
+					
+					<a href="<?php echo url('show/listing/clients'); ?>" class="btn btn-info">
+						<span class="bigger-150"><?php echo $obj->total; ?> </span>
+						<br>
+						Total Clients
+					</a>	
 					<a href="<?php echo url('show/listing/clients'); ?>" class="btn btn-info">
 						<span class="bigger-150"> <?php echo $obj->lastmonth; ?> </span>
 						<br>

--- a/app/views/widgets/client_widget.php
+++ b/app/views/widgets/client_widget.php
@@ -35,6 +35,11 @@ $obj = current($queryobj->query($sql));
 				<?php if($obj): ?>
 
 					<a href="<?php echo url('show/listing/clients'); ?>" class="btn btn-info">
+						<span class="bigger-150"><?php echo $obj->total; ?> </span>
+						<br>
+						Total Clients
+					</a>	
+					<a href="<?php echo url('show/listing/clients'); ?>" class="btn btn-info">
 						<span class="bigger-150"> <?php echo $obj->lastmonth; ?> </span>
 						<br>
 						This mo

--- a/app/views/widgets/client_widget.php
+++ b/app/views/widgets/client_widget.php
@@ -35,11 +35,6 @@ $obj = current($queryobj->query($sql));
 				<?php if($obj): ?>
 
 					<a href="<?php echo url('show/listing/clients'); ?>" class="btn btn-info">
-						<span class="bigger-150"><?php echo $obj->total; ?> </span>
-						<br>
-						Total Clients
-					</a>	
-					<a href="<?php echo url('show/listing/clients'); ?>" class="btn btn-info">
 						<span class="bigger-150"> <?php echo $obj->lastmonth; ?> </span>
 						<br>
 						This mo

--- a/app/views/widgets/disk_report_widget.php
+++ b/app/views/widgets/disk_report_widget.php
@@ -5,26 +5,26 @@
 				<div class="panel-heading">
 
 					<h3 class="panel-title"><i class="fa fa-hdd-o"></i> <span data-i18n="free_disk_space">Free Disk Space</span></h3>
-				
+
 				</div>
 
 				<div class="panel-body text-center">
 
 
-					<a id="disk-danger" href="<?php echo url('show/listing/disk#'.rawurlencode('freespace < 5GB')); ?>" class="btn btn-danger hide">
-						<span class="bigger-150"></span><br>
-						&lt; 5GB
+					<a id="disk-danger" class="btn btn-danger hide">
+						<span class="disk-count bigger-150"></span><br>
+						<span class="disk-label"></span>
 					</a>
-					<a id="disk-warning" href="<?php echo url('show/listing/disk#'.rawurlencode('5GB freespace 10GB')); ?>" class="btn btn-warning hide">
-						<span class="bigger-150"></span><br>
-						&lt; 10GB
+					<a id="disk-warning" class="btn btn-warning hide">
+						<span class="disk-count bigger-150"></span><br>
+						<span class="disk-label"></span>
 					</a>
-					<a id="disk-success" href="<?php echo url('show/listing/disk#'.rawurlencode('freespace > 10GB')); ?>" class="btn btn-success hide">
-						<span class="bigger-150"></span><br>
-						10GB +
+					<a id="disk-success" class="btn btn-success hide">
+						<span class="disk-count bigger-150"></span><br>
+						<span class="disk-label"></span>
 					</a>
 
-                    <span id="disk-nodata" data-i18n="no_clients"></span>
+          <span id="disk-nodata" data-i18n="no_clients"></span>
 
 				</div>
 
@@ -42,14 +42,31 @@ $(document).on('appReady appUpdate', function(e, lang) {
     		return;
     	}
 
+			// Get limits
+			var dangerThreshold = data.thresholds.danger+'GB',
+					warningThreshhold = data.thresholds.warning+'GB',
+					url = appUrl + '/show/listing/disk#'
+
+			// Set urls
+			$('#disk-danger').attr('href', url + encodeURIComponent('freespace < '+dangerThreshold))
+			$('#disk-warning').attr('href', url + encodeURIComponent(dangerThreshold+' freespace '+warningThreshhold))
+			$('#disk-success').attr('href', url + encodeURIComponent('freespace > '+warningThreshhold))
+
+			// Set labels
+			$('#disk-danger span.disk-label').text('< '+dangerThreshold)
+			$('#disk-warning span.disk-label').text('< '+warningThreshhold)
+			$('#disk-success span.disk-label').text(warningThreshhold+' +')
+
+			// encodeURIComponent
+
         // Show no clients span
         $('#disk-nodata').removeClass('hide');
 
-        $.each(data, function(prop, val){
+        $.each(data.stats, function(prop, val){
             if(val > 0)
             {
                 $('#disk-' + prop).removeClass('hide');
-                $('#disk-' + prop + '>span').text(val);
+                $('#disk-' + prop + '>span.disk-count').text(val);
 
                 // Hide no clients span
                 $('#disk-nodata').addClass('hide');

--- a/assets/client_installer/postflight
+++ b/assets/client_installer/postflight
@@ -29,28 +29,40 @@ def main():
     # Try to run postflight.d
     postflightscriptdir = os.path.join(scriptdir, "postflight.d")
     reportcommon.rundir(postflightscriptdir, runtype, False)
-        
+
     # Get serial
     hardware_info = munkicommon.get_hardware_info()
+    hardware_info['computer_name'] = reportcommon.get_computername()
+    hardware_info['cpu'] = reportcommon.get_cpuinfo()
+    hardware_info['cpu_arch'] = os.uname()[4]
+    hardware_info['hostname'] = os.uname()[1]
+    hardware_info['os_version'] = \
+        munkicommon.getOsVersion(only_major_minor=False)
+    hardware_info['buildversion'] = \
+        reportcommon.get_buildversion()
     serial = hardware_info.get('serial_number', 'NO_SERIAL')
-    
+    hw_info_plist = FoundationPlist.writePlistToString(hardware_info)
+
     items = {} # item list
     report_info = {}
     report_info['console_user'] = "%s" % munkicommon.getconsoleuser()
     report_info['runtype'] = runtype
     report_info['runstate'] = 'done'
-    report_info['uptime'] = reportcommon.get_uptime()    
+    report_info['uptime'] = reportcommon.get_uptime()
     report_info_plist = FoundationPlist.writePlistToString(report_info)
-    items = {'reportdata':{'hash':hashlib.md5(report_info_plist).hexdigest(), \
-        'data':report_info_plist}}
+    items = {'machine': \
+        {'hash':hashlib.md5(hw_info_plist).hexdigest(), 'data':hw_info_plist}, \
+            'reportdata': \
+        {'hash':hashlib.md5(report_info_plist).hexdigest(), \
+            'data':report_info_plist}}
     
     # Read config file /Library/Preferences/Munkireport.plist
     config_items = reportcommon.pref('ReportItems') or {}
-    
+
     for key, val in config_items.items():
         reportcommon.display_detail("Requesting %s" % key)
         items[key] = {'path':val}
-        
+
     reportcommon.process(serial, items)
 
     exit(0)

--- a/assets/js/munkireport.js
+++ b/assets/js/munkireport.js
@@ -3,7 +3,7 @@
 $( document ).ready(function() {
     $.i18n.init({
         debug: munkireport.debug,
-        useLocalStorage: ! munkireport.debug,
+        useLocalStorage: false,
         resGetPath: munkireport.subdirectory + "assets/locales/__lng__.json",
         fallbackLng: 'en',
         useDataAttrOptions: true

--- a/config_default.php
+++ b/config_default.php
@@ -504,6 +504,19 @@
 
 	/*
 	|===============================================
+	| Disk Report Widget Thresholds
+	|===============================================
+	|
+	| Thresholds for disk report widget. This array holds two values:
+	| free gigabytes below which the level is set to 'danger'
+	| free gigabytes below which the level is set as 'warning'
+	| If there are more free bytes, the level is set to 'success'
+	|
+	*/
+	$conf['disk_thresholds'] = array('danger' => 5, 'warning' => 10);
+
+	/*
+	|===============================================
 	| App settings
 	|===============================================
 	|


### PR DESCRIPTION
Currently, you can only see the total client count on the Clients Report page. Seems obvious that the total client count should be on the Dashboard too.