### PR TITLE
Adjust ActiveDirectory computer name detection

### DIFF
--- a/app/modules/directory_service/scripts/directoryservice.sh
+++ b/app/modules/directory_service/scripts/directoryservice.sh
@@ -24,16 +24,18 @@ case "$DS" in
 	# osvers is 10 for 10.6, 11 for 10.7, 12 for 10.8, 13 for 10.9, etc.
 	osversionlong=$(uname -r)
 	osvers=${osversionlong/.*/}
-	localhostname=`/usr/sbin/scutil --get LocalHostName`
+	
 	# Set variable for Domain
 	domain=`dscl localhost -list /Active\ Directory`
+	# Get AD computer object name
+	adbindname=$(defaults read "/Library/Preferences/OpenDirectory/Configurations/Active Directory/$domain" trustaccount)
 	
 	if [[ ${osvers} -ge 11 ]]; then
-		AD_COMMENTS=`dscl /Search -read Computers/"${localhostname}"$ Comment 2>/dev/null | tr -d '\n' | awk '{$1 =""; print }'`
+		AD_COMMENTS=`dscl /Search -read Computers/"${adbindname}"$ Comment 2>/dev/null | tr -d '\n' | awk '{$1 =""; print }'`
 	fi
 	
 	if [ "${osvers}" = 10 ]; then
-		AD_COMMENTS=`dscl /Active\ Directory/All\ Domains/ -read Computers/"${localhostname}"$ Comment 2>/dev/null | tr -d '\n' | awk '{$1 =""; print }'`	
+		AD_COMMENTS=`dscl /Active\ Directory/All\ Domains/ -read Computers/"${adbindname}"$ Comment 2>/dev/null | tr -d '\n' | awk '{$1 =""; print }'`	
 	fi
 	
 	echo "Active Directory Comments = ${AD_COMMENTS}" >> "$DIR/cache/directoryservice.txt"


### PR DESCRIPTION
The original directoryservice.sh script assumed the hostname was the AD binding object name for the computer object.  That's not always the case.

I've added code to detect the binding name from the AD config on the machine and use that to look up computer object comments with dscl.

We do not have comments in our computer objects so anyone that can test this change would be appreciated.