### PR TITLE
Additional HTTP Headers/Basic Auth Support for install & submit

### DIFF
--- a/app/modules/ard/scripts/install.sh
+++ b/app/modules/ard/scripts/install.sh
@@ -7,7 +7,7 @@ PREF_FILE="/Library/Preferences/com.apple.RemoteDesktop.plist"
 CTL="${BASEURL}index.php?/module/${MODULE_NAME}/"
 
 # Get the scripts in the proper directories
-${CURL} "${CTL}get_script/${MODULESCRIPT}" -o "${MUNKIPATH}preflight.d/${MODULESCRIPT}"
+"${CURL[@]}" "${CTL}get_script/${MODULESCRIPT}" -o "${MUNKIPATH}preflight.d/${MODULESCRIPT}"
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/app/modules/bluetooth/scripts/install.sh
+++ b/app/modules/bluetooth/scripts/install.sh
@@ -4,7 +4,7 @@
 CTL="${BASEURL}index.php?/module/bluetooth/"
 
 # Get the scripts in the proper directories
-${CURL} "${CTL}get_script/bluetooth.sh" -o "${MUNKIPATH}preflight.d/bluetooth.sh"
+"${CURL[@]}" "${CTL}get_script/bluetooth.sh" -o "${MUNKIPATH}preflight.d/bluetooth.sh"
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/app/modules/certificate/scripts/install.sh
+++ b/app/modules/certificate/scripts/install.sh
@@ -7,7 +7,7 @@ PREF_FILE="${CACHEPATH}certificate.txt"
 CTL="${BASEURL}index.php?/module/${MODULE_NAME}/"
 
 # Get the scripts in the proper directories
-${CURL} "${CTL}get_script/${MODULESCRIPT}" -o "${MUNKIPATH}preflight.d/${MODULESCRIPT}"
+"${CURL[@]}" "${CTL}get_script/${MODULESCRIPT}" -o "${MUNKIPATH}preflight.d/${MODULESCRIPT}"
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/app/modules/crashplan/scripts/install.sh
+++ b/app/modules/crashplan/scripts/install.sh
@@ -7,7 +7,7 @@ MODULE_CACHE_FILE="crashplan.txt"
 CTL="${BASEURL}index.php?/module/${MODULE_NAME}/"
 
 # Get the scripts in the proper directories
-${CURL} "${CTL}get_script/${MODULESCRIPT}" -o "${MUNKIPATH}preflight.d/${MODULESCRIPT}"
+"${CURL[@]}" "${CTL}get_script/${MODULESCRIPT}" -o "${MUNKIPATH}preflight.d/${MODULESCRIPT}"
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/app/modules/directory_service/scripts/install.sh
+++ b/app/modules/directory_service/scripts/install.sh
@@ -4,7 +4,7 @@
 CTL="${BASEURL}index.php?/module/directory_service/"
 
 # Get the scripts in the proper directories
-${CURL} "${CTL}get_script/directoryservice.sh" -o "${MUNKIPATH}preflight.d/directoryservice.sh"
+"${CURL[@]}" "${CTL}get_script/directoryservice.sh" -o "${MUNKIPATH}preflight.d/directoryservice.sh"
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/app/modules/disk_report/scripts/install.sh
+++ b/app/modules/disk_report/scripts/install.sh
@@ -4,7 +4,7 @@
 DR_CTL="${BASEURL}index.php?/module/disk_report/"
 
 # Get the scripts in the proper directories
-${CURL} "${DR_CTL}get_script/disk_info" -o "${MUNKIPATH}preflight.d/disk_info"
+"${CURL[@]}" "${DR_CTL}get_script/disk_info" -o "${MUNKIPATH}preflight.d/disk_info"
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/app/modules/displays_info/scripts/install.sh
+++ b/app/modules/displays_info/scripts/install.sh
@@ -4,7 +4,7 @@
 CTL="${BASEURL}index.php?/module/displays_info/"
 
 # Get the scripts in the proper directories
-${CURL} "${CTL}get_script/displays.py" -o "${MUNKIPATH}preflight.d/displays.py"
+"${CURL[@]}" "${CTL}get_script/displays.py" -o "${MUNKIPATH}preflight.d/displays.py"
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/app/modules/filevault_status/scripts/install.sh
+++ b/app/modules/filevault_status/scripts/install.sh
@@ -4,7 +4,7 @@
 FV_CTL="${BASEURL}index.php?/module/filevault_status/"
 
 # Get the scripts in the proper directories
-${CURL}  "${FV_CTL}get_script/filevaultstatus" -o "${MUNKIPATH}preflight.d/filevaultstatus" \
+"${CURL[@]}" "${FV_CTL}get_script/filevaultstatus" -o "${MUNKIPATH}preflight.d/filevaultstatus" \
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/app/modules/inventory/scripts/install.sh
+++ b/app/modules/inventory/scripts/install.sh
@@ -4,7 +4,7 @@
 DR_CTL="${BASEURL}index.php?/module/inventory/"
 
 # Get the scripts in the proper directories
-${CURL} "${DR_CTL}get_script/inventory_add_plugins" -o "${MUNKIPATH}postflight.d/inventory_add_plugins.py"
+"${CURL[@]}" "${DR_CTL}get_script/inventory_add_plugins" -o "${MUNKIPATH}postflight.d/inventory_add_plugins.py"
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/app/modules/localadmin/scripts/install.sh
+++ b/app/modules/localadmin/scripts/install.sh
@@ -4,7 +4,7 @@
 CTL="${BASEURL}index.php?/module/localadmin/"
 
 # Get the scripts in the proper directories
-${CURL} "${CTL}get_script/localadmin" -o "${MUNKIPATH}preflight.d/localadmin"
+"${CURL[@]}" "${CTL}get_script/localadmin" -o "${MUNKIPATH}preflight.d/localadmin"
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/app/modules/network/scripts/install.sh
+++ b/app/modules/network/scripts/install.sh
@@ -4,7 +4,7 @@
 NW_CTL="${BASEURL}index.php?/module/network/"
 
 # Get the script in the proper directory
-${CURL} "${NW_CTL}get_script/networkinfo.sh" -o "${MUNKIPATH}preflight.d/networkinfo.sh"
+"${CURL[@]}" "${NW_CTL}get_script/networkinfo.sh" -o "${MUNKIPATH}preflight.d/networkinfo.sh"
 
 if [ "${?}" != 0 ]
 then

--- a/app/modules/power/scripts/install.sh
+++ b/app/modules/power/scripts/install.sh
@@ -4,7 +4,7 @@
 CTL="${BASEURL}index.php?/module/power/"
 
 # Get the scripts in the proper directories
-${CURL} "${CTL}get_script/power.sh" -o "${MUNKIPATH}preflight.d/power.sh"
+"${CURL[@]}" "${CTL}get_script/power.sh" -o "${MUNKIPATH}preflight.d/power.sh"
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/app/modules/printer/scripts/install.sh
+++ b/app/modules/printer/scripts/install.sh
@@ -4,7 +4,7 @@
 CTL="${BASEURL}index.php?/module/printer/"
 
 # Get the scripts in the proper directories
-${CURL} "${CTL}get_script/printer.py" -o "${MUNKIPATH}preflight.d/printer.py"
+"${CURL[@]}" "${CTL}get_script/printer.py" -o "${MUNKIPATH}preflight.d/printer.py"
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/app/modules/profile/scripts/install.sh
+++ b/app/modules/profile/scripts/install.sh
@@ -4,7 +4,7 @@
 CTL="${BASEURL}index.php?/module/profile/"
 
 # Get the scripts in the proper directories
-${CURL} "${CTL}get_script/profile.py" -o "${MUNKIPATH}preflight.d/profile.py"
+"${CURL[@]}" "${CTL}get_script/profile.py" -o "${MUNKIPATH}preflight.d/profile.py"
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/app/modules/servermetrics/scripts/install.sh
+++ b/app/modules/servermetrics/scripts/install.sh
@@ -7,8 +7,8 @@ mkdir -p ${MUNKIPATH}munkireportlib
 CTL="${BASEURL}index.php?/module/servermetrics/"
 
 # Get the scripts in the proper directories
-${CURL} "${CTL}get_script/servermetrics.py" -o "${MUNKIPATH}preflight.d/servermetrics.py" && 
-${CURL} "${CTL}get_script/ccl_asldb.py" -o "${MUNKIPATH}munkireportlib/ccl_asldb.py"
+"${CURL[@]}" "${CTL}get_script/servermetrics.py" -o "${MUNKIPATH}preflight.d/servermetrics.py" && 
+"${CURL[@]}" "${CTL}get_script/ccl_asldb.py" -o "${MUNKIPATH}munkireportlib/ccl_asldb.py"
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/app/modules/service/scripts/install.sh
+++ b/app/modules/service/scripts/install.sh
@@ -7,7 +7,7 @@ MODULE_CACHE_FILE="services.txt"
 CTL="${BASEURL}index.php?/module/${MODULE_NAME}/"
 
 # Get the scripts in the proper directories
-${CURL} "${CTL}get_script/${MODULESCRIPT}" -o "${MUNKIPATH}preflight.d/${MODULESCRIPT}"
+"${CURL[@]}" "${CTL}get_script/${MODULESCRIPT}" -o "${MUNKIPATH}preflight.d/${MODULESCRIPT}"
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/app/modules/timemachine/scripts/install.sh
+++ b/app/modules/timemachine/scripts/install.sh
@@ -4,7 +4,7 @@
 CTL="${BASEURL}index.php?/module/timemachine/"
 
 # Get the scripts in the proper directories
-${CURL} "${CTL}get_script/timemachine.sh" -o "${MUNKIPATH}preflight.d/timemachine.sh"
+"${CURL[@]}" "${CTL}get_script/timemachine.sh" -o "${MUNKIPATH}preflight.d/timemachine.sh"
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/app/modules/warranty/scripts/install.sh
+++ b/app/modules/warranty/scripts/install.sh
@@ -4,7 +4,7 @@
 CTL="${BASEURL}index.php?/module/warranty/"
 
 # Get the scripts in the proper directories
-${CURL} "${CTL}get_script/warranty" -o "${MUNKIPATH}preflight.d/warranty"
+"${CURL[@]}" "${CTL}get_script/warranty" -o "${MUNKIPATH}preflight.d/warranty"
 
 # Check exit status of curl
 if [ $? = 0 ]; then

--- a/assets/client_installer/reportcommon
+++ b/assets/client_installer/reportcommon
@@ -61,6 +61,13 @@ def curl(url, values):
     options["content_type"] = "application/x-www-form-urlencoded"
     options["body"] = urlencode(values)
     options["logging_function"] = display_detail
+    if pref('UseMunkiAdditionalHttpHeaders'):
+        custom_headers = munkicommon.pref(munkicommon.ADDITIONAL_HTTP_HEADERS_KEY)
+        options["additional_headers"] = dict()
+        for header in custom_headers:
+            m = re.search(r'^(?P<header_name>.*?): (?P<header_value>.*?)$', header)
+            if m:
+                options["additional_headers"][m.group('header_name')] = m.group('header_value')
 
     # Build Purl with initial settings
     connection = Purl.alloc().initWithOptions_(options)


### PR DESCRIPTION
An updated version of Pull Request #192:

Submit Munki's additional HTTP headers along with any curl/purl connection, if the 'UseMunkiAdditionalHttpHeaders' MunkiReport pref is set on the client (this is helpful if you're hosting Munki & MunkiReport on the same server while also using [HTTP Basic Auth](https://github.com/munki/munki/wiki/Using-Basic-Authentication)). Also modernizes/improves curl command building in install_script.php & modules' install.sh scripts to correctly handle complex quoted arguments (like HTTP headers).

If installing from a server that requires HTTP Basic auth, you may want to run the installer as follows:

    sudo defaults write /Library/Preferences/MunkiReport UseMunkiAdditionalHttpHeaders -bool YES
    sudo /bin/bash -c "$(curl -s -H "Authorization: Basic INSERT_AUTH_HASH_HERE" https://example.com/index.php?/install