### PR TITLE
CoreLocation Module Squashed Commit

### DIFF
--- a/app/modules/location/README.md
+++ b/app/modules/location/README.md
@@ -34,12 +34,12 @@ The call out to Google's API can be disabled if you wish. If you disable this ap
 Disable Google API loopups:
 
 ```bash
-sudo defaults write /Library/Preferences/MunkiReport ReportPrefs -dict-add google_api_lookup -bool True
+sudo defaults write /Library/Preferences/MunkiReport ReportPrefs -dict-add google_api_lookup -bool False
 ````
 
 Re-enable Google API lookups (default):
 ```bash
-sudo defaults write /Library/Preferences/MunkiReport ReportPrefs -dict-add google_api_lookup -bool False
+sudo defaults write /Library/Preferences/MunkiReport ReportPrefs -dict-add google_api_lookup -bool True
 ```
 
 This can also be disabled with a profile. Example: [@clburlison/profiles](https://github.com/clburlison/profiles/blob/master/MunkiReportDisableAddressLookups.mobileconfig).
@@ -48,7 +48,7 @@ This can also be disabled with a profile. Example: [@clburlison/profiles](https:
 Notes
 ==============
 
-The following data is created by this script:
+The following data is created by this script and can be accessed via MunkiReports API:
 
 * Address - Str, Estimated street address
 * Latitude - Str, Latitude

--- a/app/modules/location/README.md
+++ b/app/modules/location/README.md
@@ -1,0 +1,43 @@
+Location module
+==============
+
+Provides location information on where a Mac is physical located.
+
+The script uses Apple's CoreLocation framework to determine the approximate latitude, and longitude of a Mac.
+
+Author: Clayton Burlison <https://clburlison.com>  
+Created: Jan. 25, 2016  
+
+Based off of works by:  
+@arubdesu - https://gist.github.com/arubdesu/b72585771a9f606ad800  
+@pudquick - https://gist.github.com/pudquick/c7dd1262bd81a32663f0  
+@pudquick - https://gist.github.com/pudquick/329142c1740500bd3797  
+@lindes   - https://github.com/lindes/get-location/  
+University of Utah, Marriott Library - https://github.com/univ-of-utah-marriott-library-apple/privacy_services_manager  
+
+
+Limitations
+==============
+
+This module is limited to 10.8 - 10.11. On each run Location Services will be enabled, and the system Python binary will be given access to Location Services. Due to how Location Services and the CoreLocation framework interact the first run to enable all the services takes about 50 seconds to run while sequential runs take about 10 seconds.
+
+We are using Google's Geocoding API for reverse address lookup. This API comes with the following limits: https://developers.google.com/maps/documentation/geocoding/usage-limits
+
+* 2,500 free requests per day
+* 10 requests per second
+
+Notes
+==============
+
+The following data is created by this script:
+
+* Address - Str, Estimated street address
+* Latitude - Str, Latitude
+* Longitude - Str, Longitude
+* LatitudeAccuracy - Int, Latitude Accuracy
+* LongitudeAccuracy - Int, Longitude Accuracy
+* Altitude - Int, Altitude
+* GoogleMap - Str, Pre-populated Google Maps URL
+* LastRun - Str, Last run time stored in UTC time
+* CurrentStatus - Str, Friendly message describing last run
+* LS_Enabled - Bool, are Location Services enabled.

--- a/app/modules/location/README.md
+++ b/app/modules/location/README.md
@@ -18,13 +18,32 @@ University of Utah, Marriott Library - https://github.com/univ-of-utah-marriott-
 
 Limitations
 ==============
+This module is limited to 10.8 - 10.11. On each run Location Services will be enabled, and the system Python binary will be given access to Location Services (LS). Due to how LS and the CoreLocation framework interact the first run to enable all the services has an exit after enabling Python plus LS. This exit will normally not be seen as Munki will automatically deploy the script and provide lookups on the second automatic munki run. The reason for this "delay" in activation is because the services need about 30 seconds to initialize the locationd daemon. However, munki's preflight script will timeout the script for waiting too long. After initial setup, sequential runs take about 6-8 seconds and have a pretty high accuracy.
 
-This module is limited to 10.8 - 10.11. On each run Location Services will be enabled, and the system Python binary will be given access to Location Services. Due to how Location Services and the CoreLocation framework interact the first run to enable all the services takes about 50 seconds to run while sequential runs take about 10 seconds.
-
-We are using Google's Geocoding API for reverse address lookup. This API comes with the following limits: https://developers.google.com/maps/documentation/geocoding/usage-limits
+We are using Google's Geocoding API for reverse address lookup. This API comes with the following limits: 
 
 * 2,500 free requests per day
 * 10 requests per second
+
+Additional information can be found: https://developers.google.com/maps/documentation/geocoding/usage-limits
+
+Settings
+==============
+The call out to Google's API can be disabled if you wish. If you disable this api call the only data provided to MunkiReport will be client side data from CoreLocation: Latitude, Longitude, Accuracy, and Altitude.
+
+Disable Google API loopups:
+
+```bash
+sudo defaults write /Library/Preferences/MunkiReport ReportPrefs -dict-add google_api_lookup -bool True
+````
+
+Re-enable Google API lookups (default):
+```bash
+sudo defaults write /Library/Preferences/MunkiReport ReportPrefs -dict-add google_api_lookup -bool False
+```
+
+This can also be disabled with a profile. Example: [@clburlison/profiles](https://github.com/clburlison/profiles/blob/master/MunkiReportDisableAddressLookups.mobileconfig).
+
 
 Notes
 ==============

--- a/app/modules/location/location_controller.php
+++ b/app/modules/location/location_controller.php
@@ -1,0 +1,30 @@
+<?php 
+
+/**
+ * location status module class
+ *
+ * @package munkireport
+ * @author
+ **/
+class Location_controller extends Module_controller
+{
+	
+	/*** Protect methods with auth! ****/
+	function __construct()
+	{
+		// Store module path
+		$this->module_path = dirname(__FILE__);
+	}
+
+	/**
+	 * Default method
+	 *
+	 * @author AvB
+	 **/
+	function index()
+	{
+		echo "You've loaded the location module!";
+	}
+
+	
+} // END class default_module

--- a/app/modules/location/location_controller.php
+++ b/app/modules/location/location_controller.php
@@ -25,6 +25,19 @@ class Location_controller extends Module_controller
 	{
 		echo "You've loaded the location module!";
 	}
-
+		/**
+		* Retrieve data in json format
+		*
+		**/
+		function get_data($serial_number = '')
+		{
+				$obj = new View();
+				if( ! $this->authorized())
+				{
+						$obj->view('json', array('msg' => 'Not authorized'));
+				}
+				$ard = new location_model($serial_number);
+				$obj->view('json', array('msg' => $location->rs));
+			}
 	
-} // END class default_module
+} // END class location_controller

--- a/app/modules/location/location_model.php
+++ b/app/modules/location/location_model.php
@@ -1,0 +1,76 @@
+<?php
+class Location_model extends Model {
+
+	function __construct($serial='')
+	{
+		parent::__construct('id', 'location'); //primary key, tablename
+		$this->rs['id'] = '';
+		$this->rs['serial_number'] = $serial; $this->rt['serial_number'] = 'VARCHAR(255) UNIQUE';
+		$this->rs['address'] = '';
+		$this->rs['altitude'] = 0;
+		$this->rs['currentstatus'] = '';
+		$this->rs['ls_enabled'] = 0;
+		$this->rs['lastrun'] = '';
+		$this->rs['latitude'] = 0.0;
+		$this->rs['latitudeaccuracy'] = 0;
+		$this->rs['longitude'] = 0.0;
+		$this->rs['longitudeaccuracy'] = 0;
+
+		// Schema version, increment when creating a db migration
+		$this->schema_version = 0;
+		
+		// Create table if it does not exist
+		$this->create_table();
+		
+		if ($serial)
+			$this->retrieve_one('serial_number=?', $serial);
+		
+		$this->serial = $serial;
+		  
+	}
+	
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Process data sent by postflight
+	 *
+	 * @param string data
+	 * 
+	 **/
+	function process($data)
+	{		
+		require_once(APP_PATH . 'lib/CFPropertyList/CFPropertyList.php');
+		$parser = new CFPropertyList();
+		$parser->parse($data);
+		
+		$plist = $parser->toArray();
+		
+		// Translate location strings to db fields
+		$translate = array(
+			'Address' => 'address',
+			'Altitude' => 'altitude',
+			'CurrentStatus' => 'currentstatus',
+			'GoogleMap' => 'googlemap',
+			'LS_Enabled' => 'ls_enabled',
+			'LastRun' => 'lastrun',
+			'Latitude' => 'latitude',
+			'LatitudeAccuracy' => 'latitudeaccuracy',
+			'Longitude' => 'longitude',
+			'LongitudeAccuracy' => 'longitudeaccuracy');
+
+		// Parse data
+		foreach($translate as $search => $field) {
+			    
+			if (isset($plist[$search]))
+			{
+				$this->$field = $plist[$search];
+			}
+			else
+			{
+				$this->$field = '';
+			}
+		}
+				    
+		$this->save();
+	}
+}

--- a/app/modules/location/scripts/install.sh
+++ b/app/modules/location/scripts/install.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# map controller
+CTL="${BASEURL}index.php?/module/location/"
+
+# Get the scripts in the proper directories
+"${CURL[@]}" "${CTL}get_script/location.py" -o "${MUNKIPATH}preflight.d/location.py"
+
+# Check exit status of curl
+if [ $? = 0 ]; then
+	# Make executable
+	chmod a+x "${MUNKIPATH}preflight.d/location.py"
+
+	# Set preference to include this file in the preflight check
+	setreportpref "location" "${CACHEPATH}location.plist"
+
+else
+	echo "Failed to download all required components!"
+	rm -f "${MUNKIPATH}preflight.d/location.py"
+
+	# Signal that we had an error
+	ERR=1
+fi
+
+

--- a/app/modules/location/scripts/location.py
+++ b/app/modules/location/scripts/location.py
@@ -1,0 +1,300 @@
+#!/usr/bin/python
+"""Enables location services (LS) globally,
+Give Python access to location services,
+Prints the current location to a plist.
+
+Author: Clayton Burlison <https://clburlison.com>
+Created: Jan. 25, 2016
+
+Based off of works by:
+@arubdesu - https://gist.github.com/arubdesu/b72585771a9f606ad800
+@pudquick - https://gist.github.com/pudquick/c7dd1262bd81a32663f0
+            https://gist.github.com/pudquick/329142c1740500bd3797
+@lindes   - https://github.com/lindes/get-location/
+University of Utah, Marriott Library -
+            https://github.com/univ-of-utah-marriott-library-apple/privacy_services_manager
+"""
+
+import sys
+import os
+import plistlib
+import platform
+import subprocess
+import tempfile
+import json
+from urllib2 import urlopen, URLError, HTTPError
+from time import gmtime, strftime, sleep
+import objc
+
+# PyLint cannot properly find names inside Cocoa libraries, so issues bogus
+# No name 'Foo' in module 'Bar' warnings. Disable them.
+# pylint: disable=E0611
+from CoreLocation import CLLocationManager, kCLDistanceFilterNone, kCLLocationAccuracyBest
+from Foundation import NSRunLoop, NSDate, NSObject
+from Foundation import NSBundle
+try:
+    sys.path.append('/usr/local/munki/munkilib/')
+    import FoundationPlist
+except ImportError as error:
+    print "Could not find FoundationPlist, are munkitools installed?"
+    raise error
+
+# Skip manual check
+if len(sys.argv) > 1:
+    if sys.argv[1] == 'manualcheck':
+        print 'Manual check: skipping'
+        exit(0)
+
+# Create cache dir if it does not exist
+# pylint: disable=C0103
+cachedir = '%s/cache' % os.path.dirname(os.path.realpath(__file__))
+if not os.path.exists(cachedir):
+    os.makedirs(cachedir)
+
+# Define location.plist
+location = cachedir + "/location.plist"
+
+plist = []
+
+# Retrieve system UUID
+IOKit_bundle = NSBundle.bundleWithIdentifier_('com.apple.framework.IOKit')
+
+functions = [("IOServiceGetMatchingService", b"II@"),
+             ("IOServiceMatching", b"@*"),
+             ("IORegistryEntryCreateCFProperty", b"@I@@I"),
+            ]
+
+objc.loadBundleFunctions(IOKit_bundle, globals(), functions)
+
+def io_key(keyname):
+    """Pythonic function to retrieve system info without a subprocess call."""
+    return IORegistryEntryCreateCFProperty(IOServiceGetMatchingService(0, \
+           IOServiceMatching("IOPlatformExpertDevice")), keyname, None, 0)
+
+def get_hardware_uuid():
+    """Returns the system UUID."""
+    return io_key("IOPlatformUUID")
+
+def root_check():
+    """Check for root access."""
+    if not os.geteuid() == 0:
+        exit("This must be run with root access.")
+
+def os_vers():
+    """Retrieve OS version."""
+    maj_os_vers = platform.mac_ver()[0].split('.')[1]
+    return maj_os_vers
+
+def os_check():
+    """Only tested on 10.8 - 10.11."""
+    if not 8 <= int(os_vers()) <= 11:
+        global plist
+        plist = dict(
+            CurrentStatus="Your OS is not supported at this time: %s." % platform.mac_ver()[0],
+            LastRun=str(current_time_GMT()),
+        )
+        plistlib.writePlist(plist, location)
+        exit("This tool only tested on 10.8 - 10.11")
+
+def current_time_GMT():
+    """Prints current date/time stamp"""
+    currentTime = strftime("%Y-%m-%d %H:%M:%S +0000", gmtime())
+    return currentTime
+
+def service_handler(action):
+    """Loads/unloads System's location services launchd job."""
+    launchctl = ['/bin/launchctl', action,
+                 '/System/Library/LaunchDaemons/com.apple.locationd.plist']
+    subprocess.check_output(launchctl)
+
+def sysprefs_boxchk():
+    """Enables location services in sysprefs globally."""
+    uuid = get_hardware_uuid()
+    perfdir = "/private/var/db/locationd/Library/Preferences/ByHost/"
+    if not os.path.exists(perfdir):
+        os.makedirs(perfdir)
+    path_stub = "/private/var/db/locationd/Library/Preferences/ByHost/com.apple.locationd."
+    das_plist = path_stub + uuid.strip() + ".plist"
+    try:
+        on_disk = FoundationPlist.readPlist(das_plist)
+    except:
+        p = {}
+        FoundationPlist.writePlist(p, das_plist)
+        on_disk = FoundationPlist.readPlist(das_plist)
+    val = on_disk.get('LocationServicesEnabled', None)
+    if val != 1:
+        service_handler('unload')
+        on_disk['LocationServicesEnabled'] = 1
+        FoundationPlist.writePlist(on_disk, das_plist)
+        os.chown(das_plist, 205, 205)
+        service_handler('load')
+
+def add_python():
+    """Python dict for clients.plist in locationd settings."""
+    auth_plist = {}
+    current_os = int(os_vers())
+    domain = 'org.python.python'
+    binary_path = ('/System/Library/Frameworks/Python.framework/'
+                   'Versions/2.7/Resources/Python.app/Contents/MacOS/Python')
+
+    if current_os == 11:
+        domain = "com.apple.locationd.executable-%s" % binary_path
+
+    das_plist = '/private/var/db/locationd/clients.plist'
+    try:
+        clients_dict = FoundationPlist.readPlist(das_plist)
+    except:
+        p = {}
+        FoundationPlist.writePlist(p, das_plist)
+        clients_dict = FoundationPlist.readPlist(das_plist)
+    val = clients_dict.get(domain, None)
+    need_to_run = False
+    try:
+        if val["Authorized"] != True:
+            need_to_run = True
+    except TypeError:
+        need_to_run = True
+    except KeyError:
+        need_to_run = True
+
+    # El Capital added a cdhash requirement that is difficult to calculate. As such we are allowing
+    # the system to correctly input the values and then giving Python access to LS.
+    if need_to_run is True:
+        service_handler('unload')
+        clients_dict[domain] = auth_plist
+        FoundationPlist.writePlist(clients_dict, das_plist)
+        os.chown(das_plist, 205, 205)
+        service_handler('load')
+        lookup(1)
+        service_handler('unload')
+        clients_dict = FoundationPlist.readPlist(das_plist)
+        auth_plist = clients_dict[domain]
+        auth_plist["Authorized"] = True
+        FoundationPlist.writePlist(clients_dict, das_plist)
+        os.chown(das_plist, 205, 205)
+        service_handler('load')
+        sleep(30)
+
+# Access CoreLocation framework to locate Mac
+is_enabled = CLLocationManager.locationServicesEnabled()
+is_authorized = CLLocationManager.authorizationStatus()
+
+class MyLocationManagerDelegate(NSObject):
+    """CoreLocation delegate for handling location lookups. This class
+    is required for python to properly start/stop lookups with location
+    services.
+    """
+    def init(self):
+        """Define location manager settings for lookups."""
+        self = super(MyLocationManagerDelegate, self).init()
+        if not self:
+            return
+        self.locationManager = CLLocationManager.alloc().init()
+        self.locationManager.setDelegate_(self)
+        self.locationManager.setDistanceFilter_(kCLDistanceFilterNone)
+        self.locationManager.setDesiredAccuracy_(kCLLocationAccuracyBest)
+        self.locationManager.startUpdatingLocation()
+        return self
+    def locationManager_didUpdateToLocation_fromLocation_(self, manager, newloc, oldloc):
+        """Splits location data into separate pieces for processing later."""
+        lat = newloc.coordinate().latitude
+        lon = newloc.coordinate().longitude
+        verAcc = newloc.verticalAccuracy()
+        horAcc = newloc.horizontalAccuracy()
+        altitude = newloc.altitude()
+        time = newloc.timestamp()
+        gmap = ("http://www.google.com/maps/place/" + str(lat) + "," + str(lon) +
+                "/@" + str(lat) + "," + str(lon) + ",18z/data=!3m1!1e3")
+
+        global plist
+        plist = dict(
+            Latitude=str(lat),
+            Longitude=str(lon),
+            LatitudeAccuracy=int(verAcc),
+            LongitudeAccuracy=int(horAcc),
+            Altitude=int(altitude),
+            GoogleMap=str(gmap),
+            LastRun=str(time),
+            CurrentStatus="Successful",
+            LS_Enabled=is_enabled,
+        )
+    def locationManager_didFailWithError_(self, manager, err):
+        """Handlers errors for location manager."""
+        if is_enabled is True:
+            if is_authorized == 3:
+                status = "Unable to locate"
+            if is_authorized == 2:
+                status = "Denied"
+            if is_authorized == 1:
+                status = "Restricted"
+            if is_authorized == 0:
+                status = "Not Determined"
+        else:
+            status = "Location Services Disabled"
+
+        global plist
+        plist = dict(
+            CurrentStatus="Unsuccessful: " + status,
+            LS_Enabled=is_enabled,
+            LastRun=str(current_time_GMT()),
+        )
+
+def lookup(lookupTime):
+    """Ask python to find current location."""
+    finder = MyLocationManagerDelegate.alloc().init()
+    NSRunLoop.currentRunLoop().runUntilDate_(NSDate.dateWithTimeIntervalSinceNow_(lookupTime))
+
+def download_file(url):
+    """Download a simple file from the ineternet."""
+    try:
+        temp_file = os.path.join(tempfile.mkdtemp(), 'tempdata')
+        f = urlopen(url)
+        with open(temp_file, "wb") as local_file:
+            local_file.write(f.read())
+    except HTTPError, e:
+        print "HTTP Error:", e.code, url
+    except URLError, e:
+        print "URL Error:", e.reason, url
+    try:
+        file_handle = open(temp_file)
+        data = file_handle.read()
+        file_handle.close()
+    except (OSError, IOError):
+        print "Couldn't read %s" % temp_file
+        return False
+    try:
+        os.unlink(temp_file)
+        os.rmdir(os.path.dirname(temp_file))
+    except (OSError, IOError):
+        pass
+    return data
+
+def address_resolve(lat, lon):
+    """Use Google's Reverse GeoCoding API to resolve coordinates to an street address."""
+    try:
+        url = 'https://maps.googleapis.com/maps/api/geocode/json?latlng=%s,%s' % (lat, lon)
+        data = download_file(url)
+        obj = json.loads(data)
+        return obj["results"][0]["formatted_address"]
+    except:
+        pass
+
+def main():
+    """Locate Mac"""
+    root_check()
+    os_check()
+    sysprefs_boxchk()
+    add_python()
+    lookup(5)
+    try:
+        if plist['Latitude']:
+            add = dict(
+                Address=str(address_resolve(plist['Latitude'], plist['Longitude'])),
+            )
+            plist.update(add)
+    except:
+        pass
+    plistlib.writePlist(plist, location)
+
+if __name__ == '__main__':
+    main()

--- a/app/modules/location/scripts/uninstall.sh
+++ b/app/modules/location/scripts/uninstall.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Remove location script
+rm -f "${MUNKIPATH}preflight.d/location.py"
+
+# Remove location.plist file
+rm -f "${MUNKIPATH}preflight.d/cache/location.plist"

--- a/app/views/client/client_detail.php
+++ b/app/views/client/client_detail.php
@@ -14,6 +14,7 @@ $tab_list = array(
 	'apple-software' => array('view' => 'client/install_history_tab', 'view_vars' => array('apple'=> 1), 'i18n' => 'client.tab.apple_software', 'badge' => 'history-cnt-1'),
 	'third-party-software' => array('view' => 'client/install_history_tab', 'view_vars' => array('apple'=> 0), 'i18n' => 'client.tab.third_party_software', 'badge' => 'history-cnt-0'),
 	'inventory-items' => array('view' => 'client/inventory_items_tab', 'i18n' => 'client.tab.inventory_items', 'badge' => 'inventory-cnt'),
+	'location-tab' => array('view' => 'client/location_tab', 'i18n' => 'client.tab.location'),
 	'network-tab' => array('view' => 'client/network_tab', 'i18n' => 'client.tab.network', 'badge' => 'network-cnt'),
 	'directory-tab' => array('view' => 'client/directory_tab', 'i18n' => 'client.tab.ds', 'badge' => 'directory-cnt'),
 	'displays-tab' => array('view' => 'client/displays_tab', 'i18n' => 'client.tab.displays', 'badge' => 'displays-cnt'),

--- a/app/views/client/location_tab.php
+++ b/app/views/client/location_tab.php
@@ -1,0 +1,64 @@
+<?php //Initialize models needed for the table
+$machine = new Machine_model($serial_number);
+$location = new location_model($serial_number);
+?>
+
+	<h2>Location</h2>
+	<table class="table table-striped">
+	<tr>
+		<td>Approximate Address: <?=$location->address?></td>
+	</tr>
+	<tr>
+		<td>Location: <?=$location->latitude?>, <?=$location->longitude?></td>
+	</tr>
+	<tr>
+		<td>Last Run: <?=$location->lastrun?></td>
+	</tr>
+	<tr>
+		<td>Location accurate within within "<?=$location->latitudeaccuracy?>" meters latitude and "<?=$location->longitudeaccuracy?>" meters longitude.</td>
+	</tr>
+	</table>
+
+    <meta charset="utf-8">
+	 <style>
+     	#map-canvas {
+        width: 512px;
+        height: 512px
+      }
+    </style>  
+    <script src="https://maps.googleapis.com/maps/api/js?v=3.exp"></script>
+    <script>
+function initialize() {
+  var myLatlng = new google.maps.LatLng(<?=$location->latitude?>,<?=$location->longitude?>);
+  var mapOptions = {
+    zoom: 15,
+    center: myLatlng
+  }
+  var map = new google.maps.Map(document.getElementById('map-canvas'), mapOptions);
+
+  var marker = new google.maps.Marker({
+      position: myLatlng,
+      map: map,
+      title: '<?=$machine->computer_name?>'
+  });
+  
+var myCity = new google.maps.Circle({
+  center:myLatlng,
+  radius:150,
+  strokeColor:"#0000FF",
+  strokeOpacity:0.2,
+  strokeWeight:1,
+  fillColor:"#0000FF",
+  fillOpacity:0.2
+  });
+
+myCity.setMap(map);
+
+}
+
+google.maps.event.addDomListener(window, 'load', initialize);
+
+    </script>
+    <div id="map-canvas"></div>
+
+    

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -107,6 +107,7 @@
 			"ds": "Directory Services",
 			"fv_escrow": "Filevault Escrow",
 			"inventory_items": "Inventory Items",
+			"location": "Location",
 			"munki": "Managed Software",
 			"network": "Network Interfaces",
 			"power": "Power",
@@ -231,6 +232,17 @@
 		"computername": "Name",
 		"hardware": {
 			"description": "Description"
+		},
+	"location": {
+		"address": "Address",
+		"altitude": "Altitude",
+		"currentstatus": "Current Status",
+		"ls_enabled": "Location Services Enabled",
+		"lastrun": "Last Run",
+		"latitude": "Latitude",
+		"latitudeaccuracy": "Latitude Accuracy",
+		"longitude": "Longitude",
+		"longitudeaccuracy": "Longitude Accuracy"
 		},
 		"loading": "Loading data from server",
 		"munki": {


### PR DESCRIPTION
This is a complete rewrite of #189 using CoreLocation to locate your Mac. However, we're still using Google's geocoding api for reverse address lookup.

Lots of community members helped make this possible:
@bochoven, @gmarnin, @pudquick, & @arubdesu all directly have code snippets that were used in creating this pull request. So :+1: to them.

This module is limited to 10.8 - 10.11. I wanted to support 10.6/10.7 however they use sqlite databases for Location Services so you'll need to upgrade those systems if you wish to use this module.

On each munki preflight run Location Services will be enabled, and the system Python binary will be given access to Location Services. ~~Due to how Location Services and the locationd daemon interact the first run to enable all the services takes about 50 seconds to run while sequential runs take about 10 seconds. ~~Most of the delay in the first run is a sleep command however that's the only reliable way for all the bits and pieces to sync up.~~ (View current Module Readme for updated info) 

If you're testing and want to reset Location Services to factory settings the following script might help: [reset_location_services.py](https://github.com/clburlison/scripts/blob/master/clburlison_scripts/reset_location_services/reset_location_services.py)

-Cheers, 
Clayton