### PR TITLE
Location updates

### DIFF
--- a/app/modules/location/README.md
+++ b/app/modules/location/README.md
@@ -46,10 +46,9 @@ sudo defaults write /Library/Preferences/MunkiReport ReportPrefs -dict-add locat
 
 This can also be disabled with a profile. Example: [@clburlison/profiles](https://github.com/clburlison/profiles/blob/master/clburlison/MunkiReportDisableAddressLookups.mobileconfig).
 
-##Error codes
-Most errors from this script 
+##Errors 
 
-| Error Code  |  Meaning |
+| Error message  |  Meaning |
 |---|---|
 | Your OS is not supported at this time  | Your OS is either too old or possibly too new for this script. |
 | Location Services was enabled. Please wait 30 seconds before doing a lookup | This status message should only be seen on the first run of this script. We need to wait 30 seconds before doing a lookup. |
@@ -59,6 +58,7 @@ Most errors from this script
 | Unsuccessful: Restricted  | CoreLocation obtained restricted access to location services. Apple Error Code: 1  |
 | Unsuccessful: Not Determined | CoreLocation could not determine a geolocation. Apple Error Code: 0 |
 | Unsuccessful: Location Services Disabled | Location Services is disabled. This is often due to your AirPort card being turned off. | 
+| Error obtaining a location. This might have occurred because you didn't wait 30 seconds after enabling location services. | You should wait. The system is doing things in the background to prep locationd for the first time. |
 
 ##Testing
 In most cases the warnings produced by this script in a normal run will provide enough information to determine what the issue is. However, if you are unsure why a lookup is failing the best way to get more information is with the `verbose` output option.

--- a/app/modules/location/README.md
+++ b/app/modules/location/README.md
@@ -5,21 +5,15 @@ Provides location information on where a Mac is physical located.
 
 The script uses Apple's CoreLocation framework to determine the approximate latitude, and longitude of a Mac.
 
-Author: Clayton Burlison <https://clburlison.com>  
+Author: Clayton Burlison - https://clburlison.com  
 Created: Jan. 25, 2016  
-
-Based off of works by:  
-@arubdesu - https://gist.github.com/arubdesu/b72585771a9f606ad800  
-@pudquick - https://gist.github.com/pudquick/c7dd1262bd81a32663f0  
-@pudquick - https://gist.github.com/pudquick/329142c1740500bd3797  
-@lindes   - https://github.com/lindes/get-location/  
-University of Utah, Marriott Library - https://github.com/univ-of-utah-marriott-library-apple/privacy_services_manager  
+Updated: Feb. 14, 2016  
 
 
-Limitations
-==============
+##Limitations
 This module is limited to 10.8 - 10.11. On each run Location Services will be enabled, and the system Python binary will be given access to Location Services (LS). Due to how LS and the CoreLocation framework interact the first run to enable all the services has an exit after enabling Python plus LS. This exit will normally not be seen as Munki will automatically deploy the script and provide lookups on the second automatic munki run. The reason for this "delay" in activation is because the services need about 30 seconds to initialize the locationd daemon. However, munki's preflight script will timeout the script for waiting too long. After initial setup, sequential runs take about 6-8 seconds and have a pretty high accuracy.
 
+###Google Geocoding API
 We are using Google's Geocoding API for reverse address lookup. This API comes with the following limits: 
 
 * 2,500 free requests per day
@@ -27,26 +21,59 @@ We are using Google's Geocoding API for reverse address lookup. This API comes w
 
 Additional information can be found: https://developers.google.com/maps/documentation/geocoding/usage-limits
 
-Settings
-==============
+###CoreLocation
+CoreLocation requires a wireless adapter to obtain lookup information. On older Macs that did not ship with a wireless adapter this script will exit without enabling Location Services or authorizing Python for lookups. If your Mac has the wireless card disabled there is a chance that this script will still obtain a location based off of CoreLocation's cached data. Your Mac does not need to be connected to an active SSID for location data to be found just enabled.
+
+Of interest:
+> Your approximate location is determined using information from local Wi-Fi networks, and is collected by Location Services in a manner that doesn’t personally identify you.
+>
+> -- https://support.apple.com/en-us/HT204690
+
+##Settings
+
 The call out to Google's API can be disabled if you wish. If you disable this api call the only data provided to MunkiReport will be client side data from CoreLocation: Latitude, Longitude, Accuracy, and Altitude.
 
 Disable Google API loopups:
 
 ```bash
-sudo defaults write /Library/Preferences/MunkiReport ReportPrefs -dict-add google_api_lookup -bool False
+sudo defaults write /Library/Preferences/MunkiReport ReportPrefs -dict-add location_address_lookup -bool False
 ````
 
-Re-enable Google API lookups (default):
+Enable Google API lookups (default):
 ```bash
-sudo defaults write /Library/Preferences/MunkiReport ReportPrefs -dict-add google_api_lookup -bool True
+sudo defaults write /Library/Preferences/MunkiReport ReportPrefs -dict-add location_address_lookup -bool True
 ```
 
-This can also be disabled with a profile. Example: [@clburlison/profiles](https://github.com/clburlison/profiles/blob/master/MunkiReportDisableAddressLookups.mobileconfig).
+This can also be disabled with a profile. Example: [@clburlison/profiles](https://github.com/clburlison/profiles/blob/master/clburlison/MunkiReportDisableAddressLookups.mobileconfig).
 
+##Error codes
+Most errors from this script 
 
-Notes
-==============
+| Error Code  |  Meaning |
+|---|---|
+| Your OS is not supported at this time  | Your OS is either too old or possibly too new for this script. |
+| Location Services was enabled. Please wait 30 seconds before doing a lookup | This status message should only be seen on the first run of this script. We need to wait 30 seconds before doing a lookup. |
+| No wireless interface found | Without a wireless interface we cannot find geodata. |
+| Unsuccessful: Unable to locate  | CoreLocation was unable to locate your Mac. Apple Error Code: 3 |
+| Unsuccessful: Denied  | CoreLocation was denied access to location service. Apple Error Code: 2  |
+| Unsuccessful: Restricted  | CoreLocation obtained restricted access to location services. Apple Error Code: 1  |
+| Unsuccessful: Not Determined | CoreLocation could not determine a geolocation. Apple Error Code: 0 |
+| Unsuccessful: Location Services Disabled | Location Services is disabled. This is often due to your AirPort card being turned off. | 
+
+##Testing
+In most cases the warnings produced by this script in a normal run will provide enough information to determine what the issue is. However, if you are unsure why a lookup is failing the best way to get more information is with the `verbose` output option.
+
+To see warnings and information use:
+```bash
+sudo /usr/local/munki/preflight.d/location.py -v
+```
+
+To see a full output of warnings, information, and debug statements use:
+```bash
+sudo /usr/local/munki/preflight.d/location.py -vv
+```
+
+##Database entries
 
 The following data is created by this script and can be accessed via MunkiReports API:
 
@@ -60,3 +87,11 @@ The following data is created by this script and can be accessed via MunkiReport
 * LastRun - Str, Last run time stored in UTC time
 * CurrentStatus - Str, Friendly message describing last run
 * LS_Enabled - Bool, are Location Services enabled.
+
+#Credits
+Based off of works by:  
+@arubdesu - https://gist.github.com/arubdesu/b72585771a9f606ad800  
+@pudquick - https://gist.github.com/pudquick/c7dd1262bd81a32663f0  
+@pudquick - https://gist.github.com/pudquick/329142c1740500bd3797  
+@lindes   - https://github.com/lindes/get-location/  
+University of Utah, Marriott Library - https://github.com/univ-of-utah-marriott-library-apple/privacy_services_manager  

--- a/app/modules/location/scripts/location.py
+++ b/app/modules/location/scripts/location.py
@@ -305,6 +305,7 @@ def main():
     sysprefs_boxchk()
     add_python()
     lookup(5)
+    global plist
     try:
         if munkireport_prefs() is True:
             if plist['Latitude']:

--- a/app/modules/location/scripts/location.py
+++ b/app/modules/location/scripts/location.py
@@ -300,8 +300,8 @@ def munkireport_prefs():
 
 def main():
     """Locate Mac"""
-    root_check()
     os_check()
+    root_check()
     sysprefs_boxchk()
     add_python()
     lookup(5)

--- a/app/modules/location/scripts/location.py
+++ b/app/modules/location/scripts/location.py
@@ -394,9 +394,11 @@ def main():
         write_to_cache_location(plist, plist['CurrentStatus'])
         logging.info("Run status: %s", plist['CurrentStatus'])
     except KeyError:
-        logging.warn("Error writing to plist. This might have "
-                     "occurred because you didn't wait 30 seconds "
-                     "after enabling location services.")
+        status = ("Error obtaining a location. This might have "
+                  "occurred because you didn't wait 30 seconds "
+                  "after enabling location services.")
+        logging.warn(status)
+        write_to_cache_location(plist, status)
 
 if __name__ == '__main__':
     main()

--- a/app/views/client/location_tab.php
+++ b/app/views/client/location_tab.php
@@ -7,6 +7,10 @@
 		<div class="col-md-6">
 			<table class="table table-striped">
 				<tr>
+					<th data-i18n="location.currentstatus"></th>
+					<td id="location-currentstatus"></td>
+				</tr>
+				<tr>
 					<th data-i18n="location.address"></th>
 					<td id="location-address"></td>
 				</tr>
@@ -42,7 +46,7 @@
 	
 $(document).on('appReady', function(e, lang) {
 	
-	// Get ARD data
+	// Get location data
 	$.getJSON( appUrl + '/module/location/get_data/' + serialNumber, function( data ) {
 		if( ! data.lastrun){
 			$('#location-msg').text(i18n.t('no_data'));
@@ -54,6 +58,7 @@ $(document).on('appReady', function(e, lang) {
 			$('#location-view').removeClass('hide');
 			
 			// Add strings
+			$('#location-currentstatus').text(data.currentstatus);
 			$('#location-address').text(data.address);
 			$('#location-coordinates').text(data.latitude + ', ' + data.longitude);
 			$('#location-altitude').text(data.altitude + 'm');

--- a/app/views/listing/location.php
+++ b/app/views/listing/location.php
@@ -1,0 +1,91 @@
+<?php $this->view('partials/head'); ?>
+
+<?php //Initialize models needed for the table
+new Machine_model;
+new Location_model;
+?>
+
+<div class="container">
+
+  <div class="row">
+
+    <div class="col-lg-12">
+
+      <h3><span data-i18n="listing.location.title"></span> <span id="total-count" class='label label-primary'>…</span></h3>
+      
+      <table class="table table-striped table-condensed table-bordered">
+        <thead>
+          <tr>
+            <th data-i18n="listing.computername" data-colname='machine.computer_name'></th>
+            <th data-i18n="serial" data-colname='reportdata.serial_number'></th>
+            <th data-i18n="location.currentstatus" data-colname='location.CurrentStatus'></th>
+            <th data-i18n="location.lastrun" data-colname='location.LastRun'></th>
+            <th data-i18n="location.address" data-colname='location.Address'></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+          <td data-i18n="listing.loading" colspan="7" class="dataTables_empty"></td>
+        </tr>
+        </tbody>
+      </table>
+    </div> <!-- /span 12 -->
+  </div> <!-- /row -->
+</div>  <!-- /container -->
+
+<script type="text/javascript">
+
+  $(document).on('appUpdate', function(e){
+
+    var oTable = $('.table').DataTable();
+    oTable.ajax.reload();
+    return;
+
+  });
+
+  $(document).on('appReady', function(e, lang) {
+    // Get column names from data attribute
+    var columnDefs = [],
+            col = 0; // Column counter
+    $('.table th').map(function(){
+              columnDefs.push({name: $(this).data('colname'), targets: col});
+              col++;
+    });
+      oTable = $('.table').dataTable( {
+          columnDefs: columnDefs,
+          ajax: {
+                url: "<?php echo url('datatables/data'); ?>",
+                type: "POST"
+            },
+            dom: mr.dt.buttonDom,
+            buttons: mr.dt.buttons,
+          createdRow: function( nRow, aData, iDataIndex ) {
+            // Update name in first column to link
+            var name=$('td:eq(0)', nRow).html();
+            if(name == ''){name = "No Name"};
+            var sn=$('td:eq(1)', nRow).html();
+            var link = get_client_detail_link(name, sn, '<?php echo url(); ?>/', '#tab_location-tab');
+            $('td:eq(0)', nRow).html(link);
+            
+            // Format Last Run date
+            var date=$('td:eq(3)', nRow).html();
+            if(date){
+              a = moment(date)
+              b = a.diff(moment(), 'years', true)
+              if(a.diff(moment(), 'years', true) < -4)
+              {
+                $('td:eq(3)', nRow).addClass('danger')
+              }
+              if(Math.round(b) == 4)
+              {
+                
+              }
+              $('td:eq(3)', nRow).addClass('text-right').html(moment(date).fromNow());
+            }
+
+          }
+      });
+  });
+</script>
+
+<?php $this->view('partials/foot'); ?>

--- a/assets/locales/de.json
+++ b/assets/locales/de.json
@@ -296,6 +296,7 @@
 			"displays": "Displays",
 			"hardware": "Hardware",
 			"inventory": "Inventar",
+			"location": "Location",
 			"munki": "Munki",
 			"network": "Netzwerk",
 			"power": "Strom",

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -312,6 +312,7 @@
 			"displays": "Displays",
 			"hardware": "Hardware",
 			"inventory": "Inventory",
+			"location": "Location",
 			"munki": "Munki",
 			"network": "Network",
 			"power": "Power",

--- a/assets/locales/fr.json
+++ b/assets/locales/fr.json
@@ -296,6 +296,7 @@
       "displays": "Moniteurs",
       "hardware": "Materiel",
       "inventory": "Inventaire",
+      "location": "Location",
       "munki": "Munki",
       "network": "Réseau",
       "power": "Alimentation",

--- a/assets/locales/nl.json
+++ b/assets/locales/nl.json
@@ -293,6 +293,7 @@
       "displays": "Beeldschermen",
       "hardware": "Hardware",
       "inventory": "Inventaris",
+      "location": "Location",
       "munki": "Munki",
       "network": "Netwerk",
       "power": "Power",

--- a/assets/locales/ru.json
+++ b/assets/locales/ru.json
@@ -111,6 +111,7 @@
 			"displays": "Мониторы",
 			"hardware": "Аппаратные средства",
 			"inventory": "Инвентарь",
+			"location": "Location",
 			"munki": "Munki",
 			"network": "Сеть",
 			"security": "Безопасность",


### PR DESCRIPTION
Pretty big update to handle more edge cases within the location module. The advanced logging should provide better feedback to admins when things don't go as planned. 

Improvements
* This should write output to `./cache/location.plist` on every run
* Check if we have a wireless adapter before enabling and running
* We write to the plist using a method now...much cleaner 
* Add a location listing
* Enabled logging within the `location.py` script
* Verbose output using `-v` and `-vv`
* Rename ReportPrefs key from  `google_api_lookup` to `location_address_lookup`. These preferences should include the module name in the key to make it more clear.
* Update module Readme to match updates 

This script does **not** enable the wireless adapter if it turned off. Instead we make the `currentstatus` output more obvious to admins via the MR interface so they are aware why the computer(s) isn't checkin/updating.

-Clayton