### PR TITLE
Fix printer.py to handle when sharing is off

### DIFF
--- a/app/modules/printer/scripts/printer.py
+++ b/app/modules/printer/scripts/printer.py
@@ -2,7 +2,7 @@
 
 # Original instance https://github.com/glarizza/scripts/blob/5c49cef74f0194411273bb425da1cf065b9e0978/python/Command.py
 
-# Printer Location is not recorded in system profiler 
+# Printer Location is not recorded in system profiler
 
 import subprocess
 import plistlib
@@ -33,29 +33,30 @@ result = ''
 
 # If no printers are installed then write 0 and exit
 if not task:
-	result = ''
-	# Write to disk
-	txtfile = open("%s/printer.txt" % cachedir, "w")
-	txtfile.write(result)
-	txtfile.close()
-	exit(0)
+    result = ''
+    # Write to disk
+    txtfile = open("%s/printer.txt" % cachedir, "w")
+    txtfile.write(result)
+    txtfile.close()
+    exit(0)
 
 #loop through all printers
 for printer in printers:
     if printer.get('uri'):
-		result += 'Name: ' + printer['_name'] + '\n'
-		result += 'PPD: ' + printer['ppd'] + '\n'
-		result += 'Driver Version: ' + printer['ppdfileversion'] + '\n'
-		result += 'URL: ' + printer['uri'] + '\n'
-		result += 'Default Set: ' + printer['default'] + '\n'
-		result += 'Printer Status: ' + printer['status'] + '\n'
-		result += 'Printer Sharing: ' + printer['printersharing']
-		result += '\n----------\n'
+        result += 'Name: ' + printer['_name'] + '\n'
+        result += 'PPD: ' + printer['ppd'] + '\n'
+        result += 'Driver Version: ' + printer['ppdfileversion'] + '\n'
+        result += 'URL: ' + printer['uri'] + '\n'
+        result += 'Default Set: ' + printer['default'] + '\n'
+        result += 'Printer Status: ' + printer['status'] + '\n'
+        try:
+            result += 'Printer Sharing: ' + printer['shared']
+        except KeyError:
+            result += 'Printer Sharing: no'
+        result += '\n----------\n'
 
 
 # Write to disk
 txtfile = open("%s/printer.txt" % cachedir, "w")
 txtfile.write(result.encode('utf-8'))
 txtfile.close()
-
-#exit(0)


### PR DESCRIPTION
As promised the Printer script fixed. No longer shall the preflight script exit 1.

I got a little lazy and only tested in 10.6, 10.7, 10.9 and 10.11. Even if 10.8 and 10.10 are different the exception for KeyError should cover us.

The 'shared' key is better as it is present on 10.6-10.11 while the 'printersharing' key was only on later OS releases.

Also linted the script while it was open. 