### PR TITLE
security module - output data on older devices

### DIFF
--- a/app/modules/security/scripts/security.sh
+++ b/app/modules/security/scripts/security.sh
@@ -20,6 +20,8 @@ if [[ ${osvers} -ge 7 ]]; then
    else
       gatekeeper=Active
    fi
+else 
+ 	  gatekeeper="Not Supported"
 #   echo "Gatekeeper is $gatekeeper"
 fi
 
@@ -33,7 +35,7 @@ if [[ ${osvers} -ge 11 ]]; then
    else
       sip=Active
    fi
-    else 
+else 
 	  sip="Not Supported"
 #   echo "SIP is $sip_status"
 fi


### PR DESCRIPTION
If less than 10.7 we should output data for Gatekeeper.
If less than 10.11 we should output data for SIP.