### PR TITLE
preserve curl options when curl-ing submit.preflight

### DIFF
--- a/app/views/install/install_script.php
+++ b/app/views/install/install_script.php
@@ -155,7 +155,7 @@ chmod a+x "${MUNKIPATH}"{preflight,postflight,report_broken_client}
 # Create preflight.d + download scripts
 mkdir -p "${MUNKIPATH}preflight.d"
 cd "${MUNKIPATH}preflight.d"
-${CURL} "${TPL_BASE}submit.preflight" --remote-name
+${CURL[@]} "${TPL_BASE}submit.preflight" --remote-name
 
 if [ "${?}" != 0 ]
 then


### PR DESCRIPTION
Mainly, this fixes so that submit.preflight is not mysteriously missing from the generated PKG when downloading from a munkireport-php server with an insecure certificate. All other curl-calls preserve --insecure, and therefore work.