### PR TITLE
Fix incorrect status on SIP

### DIFF
--- a/app/modules/security/scripts/security.sh
+++ b/app/modules/security/scripts/security.sh
@@ -29,8 +29,8 @@ fi
 # Checks SIP status on Macs running 10.11 or higher
 
 if [[ ${osvers} -ge 11 ]]; then
-    sip_status=$(/usr/bin/csrutil status | awk '{print $5}')
-   if [ "$sip_status" = "disabled" ]; then
+   sip_status=$(/usr/bin/csrutil status | awk '{print $5}')
+   if [ "$sip_status" = "disabled." ]; then
       sip=Disabled
    else
       sip=Active

--- a/app/modules/security/scripts/security.sh
+++ b/app/modules/security/scripts/security.sh
@@ -30,7 +30,7 @@ fi
 
 if [[ ${osvers} -ge 11 ]]; then
    sip_status=$(/usr/bin/csrutil status | awk '{print $5}')
-   if [ "$sip_status" = "disabled." ]; then
+   if [ "$sip_status" == "disabled." ]; then
       sip=Disabled
    else
       sip=Active


### PR DESCRIPTION
he output from csrutil status has a period at the end of enabled/disabled