### PR TITLE
use proper curl command to preserve options

### DIFF
--- a/app/modules/wifi/scripts/install.sh
+++ b/app/modules/wifi/scripts/install.sh
@@ -6,7 +6,7 @@ MODULESCRIPT="wifi"
 CTL="${BASEURL}index.php?/module/${MODULE_NAME}/"
 
 # Get the scripts in the proper directories
-${CURL} -s "${CTL}get_script/${MODULESCRIPT}" -o "${MUNKIPATH}preflight.d/${MODULESCRIPT}"
+"${CURL[@]}" "${CTL}get_script/${MODULESCRIPT}" -o "${MUNKIPATH}preflight.d/${MODULESCRIPT}"
 
 # Check exit status of curl
 if [ $? = 0 ]; then


### PR DESCRIPTION
the wifi install script does not use the set of options defined, so fails on e.g. self-signed certificates

(Supersedes #453 )