### PR TITLE
Dynamic Munki Support

### DIFF
--- a/app/modules/inventory/scripts/install.sh
+++ b/app/modules/inventory/scripts/install.sh
@@ -5,12 +5,8 @@ DR_CTL="${BASEURL}index.php?/module/inventory/"
 
 # Find out where the munki directory is to set accordingly.
 munki_install_dir=$(/usr/bin/python -c 'import CoreFoundation; print CoreFoundation.CFPreferencesCopyAppValue("ManagedInstallDir", "ManagedInstalls")')
-munki_install_dir_len=$((${#munki_install_dir}-1))
+munki_install_dir=$(echo ${munki_install_dir} | sed 's/\/$//')
 
-if [[ ${munki_install_dir:$munki_install_dir_len:1} == '/' ]]; then
-    #if our custom path has a '/' at the end we should trim it off
-    munki_install_dir=$(echo ${munki_install_dir} | sed 's/.$//')
-fi
 # Get the scripts in the proper directories
 "${CURL[@]}" "${DR_CTL}get_script/inventory_add_plugins" -o "${MUNKIPATH}postflight.d/inventory_add_plugins.py"
 

--- a/app/modules/inventory/scripts/install.sh
+++ b/app/modules/inventory/scripts/install.sh
@@ -21,7 +21,7 @@ if [ $? = 0 ]; then
     # make sure the munki install directory is defined. If not default back to normal
     if [[ "${munki_install_dir}" == "None" ]]; then
         # This also intended behavior if munki isn't installed
-        setreportpref "munkireport" '/Library/Managed Installs/ApplicationInventory.plist'
+        setreportpref "inventory" '/Library/Managed Installs/ApplicationInventory.plist'
     else
         # Set preference to include this file in the preflight check
         setreportpref "inventory" "${munki_install_dir}/ApplicationInventory.plist"

--- a/app/modules/inventory/scripts/install.sh
+++ b/app/modules/inventory/scripts/install.sh
@@ -3,20 +3,31 @@
 # inventory controller
 DR_CTL="${BASEURL}index.php?/module/inventory/"
 
+# Find out where the munki directory is to set accordingly.
+munki_install_dir=$(/usr/bin/python -c 'import CoreFoundation; print CoreFoundation.CFPreferencesCopyAppValue("ManagedInstallDir", "ManagedInstalls")')
+munki_install_dir_len=$((${#munki_install_dir}-1))
+
+if [[ ${munki_install_dir:$munki_install_dir_len:1} == '/' ]]; then
+    #if our custom path has a '/' at the end we should trim it off
+    munki_install_dir=$(echo ${munki_install_dir} | sed 's/.$//')
+fi
 # Get the scripts in the proper directories
 "${CURL[@]}" "${DR_CTL}get_script/inventory_add_plugins" -o "${MUNKIPATH}postflight.d/inventory_add_plugins.py"
 
 # Check exit status of curl
 if [ $? = 0 ]; then
-	# Make executable
-	chmod a+x "${MUNKIPATH}postflight.d/inventory_add_plugins.py"
-
-	# Set preference to include this file in the preflight check
-	setreportpref "inventory" "/Library/Managed Installs/ApplicationInventory.plist"
-
+    # Make executable
+    chmod a+x "${MUNKIPATH}postflight.d/inventory_add_plugins.py"
+    # make sure the munki install directory is defined. If not default back to normal
+    if [[ "${munki_install_dir}" == "None" ]]; then
+        # This also intended behavior if munki isn't installed
+        setreportpref "munkireport" '/Library/Managed Installs/ApplicationInventory.plist'
+    else
+        # Set preference to include this file in the preflight check
+        setreportpref "inventory" "${munki_install_dir}/ApplicationInventory.plist"
+    fi
 else
-	echo "Failed to download all required components!"
-	rm -f "${MUNKIPATH}postflight.d/inventory_add_plugins.py"
-	ERR=1
+    echo "Failed to download all required components!"
+    rm -f "${MUNKIPATH}postflight.d/inventory_add_plugins.py"
+    ERR=1
 fi
-

--- a/app/modules/inventory/scripts/inventory_add_plugins
+++ b/app/modules/inventory/scripts/inventory_add_plugins
@@ -4,18 +4,30 @@ Adds Internet Plug-Ins to the Application Inventory data that is gathered
 by munki.
 Thanks to Adam Reed and Josh Malone
 """
-
 import os
 import sys
-
-sys.path.insert(0,'/usr/local/munki')
+import CoreFoundation
+sys.path.insert(0, '/usr/local/munki')
 
 from munkilib import FoundationPlist
 
-invPath = r"/Library/Managed Installs/ApplicationInventory.plist"
+# check the ManagedInstalls plist for where the ManagedInstallDir is located
+munki_install_dir = CoreFoundation.CFPreferencesCopyAppValue("ManagedInstallDir", "ManagedInstalls")
+if munki_install_dir:
+    invPath = os.path.join(munki_install_dir, 'ApplicationInventory.plist')
+else:
+    invPath = '/Library/Managed Installs/ApplicationInventory.plist'
+
+# Look for our set path to make sure it exists. If not exit because munki
+# most likely isn't installed yet
+try:
+    appinv = FoundationPlist.readPlist(invPath)
+except FoundationPlist.NSPropertyListSerializationException as e:
+    print "{0} couldn't be found. Exiting...".format(invPath)
+    exit(1)
+
 plugins = r"/Library/Internet Plug-Ins/"
 directoryListing = os.listdir(plugins)
-appinv = FoundationPlist.readPlist(invPath)
 
 print "Adding %i plugins" % len(directoryListing)
 
@@ -26,7 +38,7 @@ for x in directoryListing:
         plugin = {}
         plugin['CFBundleName'] = info.get('CFBundleName', x)
         plugin['bundleid'] = info.get('CFBundleIdentifier', 'N/A')
-        plugin['version'] = info.get('CFBundleVersion','N/A')
+        plugin['version'] = info.get('CFBundleVersion', 'N/A')
         plugin['path'] = os.path.join(plugins, x)
         plugin['name'] = info.get('CFBundleName', os.path.splitext(os.path.basename(x))[0])
         appinv.append(plugin.copy())

--- a/app/modules/munkireport/scripts/install.sh
+++ b/app/modules/munkireport/scripts/install.sh
@@ -1,3 +1,18 @@
 #!/bin/bash
 
-setreportpref "munkireport" '/Library/Managed Installs/ManagedInstallReport.plist'
+# Find out where the munki directory is so we can configure accordingly.
+munki_install_dir=$(/usr/bin/python -c 'import CoreFoundation; print CoreFoundation.CFPreferencesCopyAppValue("ManagedInstallDir", "ManagedInstalls")')
+munki_install_dir_len=$((${#munki_install_dir}-1))
+
+#check if the format of the munki_install_dir is correct.
+if [[ ${munki_install_dir:$munki_install_dir_len:1} == '/' ]]; then
+    munki_install_dir=$(echo ${munki_install_dir} | sed 's/.$//')
+fi
+# make sure the munki directory is defined. If not default back to normal
+if [[ "${munki_install_dir}" == "None" ]]; then
+    #Default back to normal since munki doesn't appear to be installed
+    setreportpref "munkireport" '/Library/Managed Installs/ManagedInstallReport.plist'
+else
+    # configure munkireport to use munki's config
+    setreportpref "munkireport" "${munki_install_dir}/ManagedInstallReport.plist"
+fi

--- a/app/modules/munkireport/scripts/install.sh
+++ b/app/modules/munkireport/scripts/install.sh
@@ -2,12 +2,8 @@
 
 # Find out where the munki directory is so we can configure accordingly.
 munki_install_dir=$(/usr/bin/python -c 'import CoreFoundation; print CoreFoundation.CFPreferencesCopyAppValue("ManagedInstallDir", "ManagedInstalls")')
-munki_install_dir_len=$((${#munki_install_dir}-1))
+munki_install_dir=$(echo ${munki_install_dir} | sed 's/\/$//')
 
-#check if the format of the munki_install_dir is correct.
-if [[ ${munki_install_dir:$munki_install_dir_len:1} == '/' ]]; then
-    munki_install_dir=$(echo ${munki_install_dir} | sed 's/.$//')
-fi
 # make sure the munki directory is defined. If not default back to normal
 if [[ "${munki_install_dir}" == "None" ]]; then
     #Default back to normal since munki doesn't appear to be installed


### PR DESCRIPTION
Currently munkireport is hard coded to munki's default install directory settings. If you change the ManagedInstallDir Preference in munki it breaks munkireport. The proposed changes uses CoreFoundation's CFPreferences to check how munki is configured (if at all) and configure munkireport accordingly.  