### PR TITLE
Events hover title to "Recently generated events"

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -249,7 +249,7 @@
 	"event": "Event",
 	"event_plural": "Events",
 	"events": {
-		"widget_title": "Events generated in the last hour"
+		"widget_title": "Recently generated events"
 	},
 	"external": {
 		"mwa_link": "Open in Munki Web Admin"


### PR DESCRIPTION
The hover title for the Events widget on the dashboard was incorrect due to recent changes to only show the last 50 events.  The previous title stated the events listed were from the last hour.