### PR TITLE
Update deploystudio_helper.php

### DIFF
--- a/app/helpers/site_helper.php
+++ b/app/helpers/site_helper.php
@@ -1,7 +1,7 @@
 <?php
 
 // Munkireport version (last number is number of commits)
-$GLOBALS['version'] = '2.9.1.2146';
+$GLOBALS['version'] = '2.9.2.2150';
 
 // Return version without commit count
 function get_version()

--- a/app/modules/deploystudio/lib/deploystudio_helper.php
+++ b/app/modules/deploystudio/lib/deploystudio_helper.php
@@ -41,7 +41,9 @@ class Deploystudio_helper {
 
     	if(array_key_exists('dstudio-last-workflow',$plist)){
     		$workflow_title = $this->get_workflow_title($plist['dstudio-last-workflow']);
-    		$deploystudio_model->{'dstudio_last_workflow'} = $workflow_title;
+            if($workflow_title != NULL){
+    		    $deploystudio_model->{'dstudio_last_workflow'} = $workflow_title;
+            }
     	}
 
       // Save the data


### PR DESCRIPTION
This fixes an issue caused when a DeployStudio workflow was deleted.

Uncaught Exception: SQLSTATE[HY000]: General error: 1366 Incorrect string value: '\xF3\xB3\x06\x00' for column 'dstudio_last_workflow' at row 1
