### PR TITLE
disk_report: Skip non-mounted volumes

### DIFF
--- a/app/modules/disk_report/scripts/disk_info
+++ b/app/modules/disk_report/scripts/disk_info
@@ -160,7 +160,7 @@ def DiskReport():
         if getattr(disk, 'Partitions', None):
             for partition in disk.Partitions:
 
-                if partition.Content == 'Apple_HFS':
+                if partition.Content == 'Apple_HFS' and partition.get('MountPoint'):
                     diskInfo = filteredDiskInfo(partition.DeviceIdentifier)
                     if diskInfo['BusProtocol'] == 'Disk Image':
                         # Skip Disk Images
@@ -190,7 +190,7 @@ def DiskReport():
                     volumeList.append(diskInfo)
 
         else:
-            if disk.Content == 'Apple_HFS':
+            if disk.Content == 'Apple_HFS' and disk.get('MountPoint'):
                 diskInfo = filteredDiskInfo(disk.DeviceIdentifier)
 
                 if diskInfo['BusProtocol'] == 'Disk Image':


### PR DESCRIPTION
Skips volumes which are not mounted, to prevent reporting wrong free space as zero bytes.