### PR TITLE
Remove `public` from function `isnotzero`

### DIFF
--- a/app/views/widgets/network_location_widget.php
+++ b/app/views/widgets/network_location_widget.php
@@ -25,7 +25,7 @@
 		$(document).on('appReady', function() {
 
 			//drawGraph("<?php echo url('module/reportdata/ip'); ?>", '#ip-plot', pieOptions, parms);
-		    public function isnotzero(point)
+		    function isnotzero(point)
 		    {
 		    	return point.cnt > 0;
 		    }


### PR DESCRIPTION
When trying to view the Network Location widget the widget is blank.
Looking at the debug log of the browser shows `Uncaught SyntaxError: Unexpected token function` and blames https://github.com/munkireport/munkireport-php/blob/06745ac2c232e9706fa7c9690e160e5cbee380c9/app/views/widgets/network_location_widget.php#L28

Removing the public declaration allows the data to be viewable in the widget again.