### PR TITLE
Update deploystudio_server sample conf to omit trailing slash

### DIFF
--- a/config_default.php
+++ b/config_default.php
@@ -295,7 +295,7 @@
 	| its data may not show in MunkiReport.
 	*/
 	$conf['deploystudio_enable'] = FALSE;
-	$conf['deploystudio_server'] = 'https://deploystudio.apple.com:60443/';
+	$conf['deploystudio_server'] = 'https://deploystudio.apple.com:60443'; // no trailing slash
 	$conf['deploystudio_username'] = 'deploystudio_user';
 	$conf['deploystudio_password'] = 'deploystudio_password';
 	


### PR DESCRIPTION
As discussed in Slack, if a trailing slash is used in this conf, the DS module throws an exception, so updating the sample config.php file. Thanks!