### PR TITLE
USB module edit

### DIFF
--- a/app/modules/usb/scripts/usb.py
+++ b/app/modules/usb/scripts/usb.py
@@ -52,7 +52,7 @@ def flatten_usb_info(array):
                 device['extra_current_used'] = obj[item]
             elif item == 'Built-in_Device' and obj[item] == 'Yes':
                 device['internal'] = 1
-            elif item == 'Media':
+            elif item == 'Media' or 'removable_media' :
                 device['media'] = 1
         out.append(device)
     return out


### PR DESCRIPTION
This wasn't catching a USB attached Drobo as mass storage and had it filed it under "unknown".
Added `removable_media` to catch the mass storage device.  

XML Output from an attached Drobo on a system running 10.11.6 is:

```
							<dict>
								<key>_name</key>
								<string>Drobo</string>
								<key>bcd_device</key>
								<string>0.00</string>
								<key>bsd_name</key>
								<string>disk2</string>
								<key>bus_power</key>
								<string>1000</string>
								<key>bus_power_used</key>
								<string>0</string>
								<key>detachable_drive</key>
								<string>yes</string>
								<key>device_speed</key>
								<string>high_speed</string>
								<key>extra_current_used</key>
								<string>0</string>
								<key>location_id</key>
								<string>0xfa130000 / 3</string>
								<key>manufacturer</key>
								<string>Drobo</string>
								<key>partition_map_type</key>
								<string>guid_partition_map_type</string>
								<key>product_id</key>
								<string>0x3344</string>
								<key>removable_media</key>
								<string>yes</string>
								<key>serial_num</key>
								<string>XXXXXXXXXXXXX</string>
								<key>size</key>
								<string>17.59 TB</string>
								<key>size_in_bytes</key>
								<integer>17592186044416</integer>
								<key>vendor_id</key>
								<string>0x19b9</string>
								<key>volumes</key>
								<array>
									<dict>
```