### PR TITLE
Update en.json

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -590,7 +590,7 @@
 	"munkireportinfo": {
 		"baseurl": "MunkiReport URL",
 		"clienttabtitle": "MunkiReport",
-		"passphrase": "Passprase",
+		"passphrase": "Passphrase",
 		"reportitems": "Installed Modules",
 		"reporttitle": "MunkiReport Report",
 		"version": "Version"


### PR DESCRIPTION
Hello,

Typing error on munkireport - passprase instead of passphrase
It's seems that we have duplicate key ( "localonlymanifest on munkiinfo)