### PR TITLE
Hardware localization fix for Listing title

### DIFF
--- a/app/modules/machine/views/hardware_listing.php
+++ b/app/modules/machine/views/hardware_listing.php
@@ -11,7 +11,7 @@ new Reportdata_model;
 
   	<div class="col-lg-12">
 
-		  <h3><span data-i18n="nav.reports.hardware"></span> <span id="total-count" class='label label-primary'>…</span></h3>
+		  <h3><span data-i18n="machine.hardware_report"></span> <span id="total-count" class='label label-primary'>…</span></h3>
 
 		  <table class="table table-striped table-condensed table-bordered">
 		    <thead>


### PR DESCRIPTION
Hardware listing was missing the report title.