### PR TITLE
Updated localadmin module

### DIFF
--- a/app/modules/localadmin/README.md
+++ b/app/modules/localadmin/README.md
@@ -9,3 +9,4 @@ The table provides the following information per 'item':
 * serial_number (string) Serial Number
 * users (string) List of admin users	   
 
+The widget shows machines that have more than one admin account.  This is assuming the first admin account is the default admin account for system administration. 

--- a/app/modules/localadmin/localadmin_controller.php
+++ b/app/modules/localadmin/localadmin_controller.php
@@ -25,4 +25,23 @@ class Localadmin_controller extends Module_controller
     {
         echo "You've loaded the localadmin module!";
     }
+
+	/**
+     * Get localadmin names for widget
+     *
+     * @return void
+     **/
+     public function get_localadmin()
+     {
+        $obj = new View();
+
+        if (! $this->authorized()) {
+            $obj->view('json', array('msg' => array('error' => 'Not authenticated')));
+            return;
+        }
+        
+        $localadmin = new Localadmin_model;
+        $obj->view('json', array('msg' => $localadmin->get_localadmin()));
+     }
+
 } // END class default_module

--- a/app/modules/localadmin/localadmin_model.php
+++ b/app/modules/localadmin/localadmin_model.php
@@ -25,6 +25,26 @@ class Localadmin_model extends Model
     
     // ------------------------------------------------------------------------
 
+     public function get_localadmin()
+     {
+        $out = array();
+        $sql = "SELECT machine.serial_number, computer_name,
+                    LENGTH(users) - LENGTH(REPLACE(users, ' ', '')) + 1 AS count,
+                    users
+                    FROM localadmin
+                    LEFT JOIN machine USING (serial_number)
+                    WHERE localadmin.users LIKE '% %'  
+                    ORDER BY count DESC";
+        
+        foreach ($this->query($sql) as $obj) {
+            if ("$obj->count" !== "0") {
+                $obj->users = $obj->users ? $obj->users : 'Unknown';
+                $out[] = $obj;
+            }
+        }
+        return $out;
+     }
+
     /**
      * Process data sent by postflight
      *

--- a/app/modules/localadmin/locales/en.json
+++ b/app/modules/localadmin/locales/en.json
@@ -1,0 +1,12 @@
+{
+	"currentuser": "Current User",
+	"localadmin": "Local Admins",
+	"nolocaladmin": "No Local Admins",
+	"title": "Local Admins Report",
+	"users": "Local Admins",
+	"widget": {
+		"title": "Local Admins",
+		"tooltip": "Local administrators on the computer."
+	}
+}
+

--- a/app/modules/localadmin/provides.php
+++ b/app/modules/localadmin/provides.php
@@ -1,0 +1,15 @@
+<?php
+
+return array(
+    'listings' => array(
+        'localadmin' => array('view' => 'localadmin', 'i18n' => 'localadmin.localadmin',),
+    ),
+    'widgets' => array(
+        array('view' => 'localadmin_widget'),
+    ),
+    'reports' => array(
+        'localadmin' => array('view' => 'localadmin_report', 'i18n' => 'localadmin.localadmin',),
+    ),
+);
+
+

--- a/app/modules/localadmin/views/localadmin.php
+++ b/app/modules/localadmin/views/localadmin.php
@@ -1,0 +1,86 @@
+<?php $this->view('partials/head')?>
+
+<?php //Initialize models needed for the table
+new Machine_model;
+new Reportdata_model;
+new Localadmin_model;
+?>
+
+<div class="container">
+
+  <div class="row">
+
+  	<div class="col-lg-12">
+
+		  <h3><span data-i18n="localadmin.title"></span> <span id="total-count" class='label label-primary'>…</span></h3>
+
+		  <table class="table table-striped table-condensed table-bordered">
+		    <thead>
+		      <tr>
+		      	<th data-i18n="listing.computername" data-colname='machine.computer_name'></th>
+		        <th data-i18n="serial" data-colname='machine.serial_number'></th>
+		        <th data-i18n="localadmin.currentuser" data-colname='reportdata.console_user'></th>
+		        <th data-i18n="localadmin.users" data-colname='localadmin.users'></th> 
+		      </tr>
+		    </thead>
+		    <tbody>
+		      <tr>
+			<td data-i18n="listing.loading" colspan="5" class="dataTables_empty"></td>
+		      </tr>
+		    </tbody>
+		  </table>
+    </div> <!-- /span 12 -->
+  </div> <!-- /row -->
+</div>  <!-- /container -->
+
+
+<script type="text/javascript">
+
+    $(document).on('appUpdate', function(e){
+
+            var oTable = $('.table').DataTable();
+            oTable.ajax.reload();
+            return;
+
+    });
+
+	$(document).on('appReady', function(e, lang) {
+
+        // Get column names from data attribute
+        var columnDefs = [], //Column Definitions
+            col = 0; // Column counter
+        $('.table th').map(function(){
+            columnDefs.push({name: $(this).data('colname'), targets: col});
+            col++;
+        });
+        var oTable = $('.table').dataTable( {
+            ajax: {
+                url: "<?php echo url('datatables/data'); ?>",
+                type: "POST",
+                data: function( d ){
+                    // Look for 'osversion' statement
+                    if(d.search.value.match(/^\d+\.\d+(\.(\d+)?)?$/)){
+                        var search = d.search.value.split('.').map(function(x){return ('0'+x).slice(-2)}).join('');
+                        d.search.value = search;
+                    }
+              
+                }
+            },
+            dom: mr.dt.buttonDom,
+            buttons: mr.dt.buttons,
+            columnDefs: columnDefs,
+            createdRow: function( nRow, aData, iDataIndex ) {
+                // Update name in first column to link
+                var name=$('td:eq(0)', nRow).html();
+                if(name == ''){name = "No Name"};
+                var sn=$('td:eq(1)', nRow).html();
+                var link = mr.getClientDetailLink(name, sn, '<?php echo url(); ?>/');
+                $('td:eq(0)', nRow).html(link);
+                    
+            }
+        } );
+    } );
+</script>
+
+<?php $this->view('partials/foot'); ?>
+

--- a/app/modules/localadmin/views/localadmin_report.php
+++ b/app/modules/localadmin/views/localadmin_report.php
@@ -1,0 +1,20 @@
+<?php $this->view('partials/head', array(
+	"scripts" => array(
+		"clients/client_list.js"
+	)
+)); ?>
+
+<div class="container">
+
+  <div class="row">
+
+    <?php $widget->view($this, 'localadmin'); ?>
+
+  </div> <!-- /row -->
+
+</div>  <!-- /container -->
+
+<script src="<?php echo conf('subdirectory'); ?>assets/js/munkireport.autoupdate.js"></script>
+
+<?php $this->view('partials/foot'); ?>
+

--- a/app/modules/localadmin/views/localadmin_widget.php
+++ b/app/modules/localadmin/views/localadmin_widget.php
@@ -1,0 +1,29 @@
+	<div class="col-lg-4 col-md-6">
+	<div class="panel panel-default">
+		<div class="panel-heading" data-container="body" data-i18n="[title]localadmin.widget.tooltip">
+			<h3 class="panel-title"><i class="fa fa-user-secret"></i> <span data-i18n="localadmin.widget.tooltip"></span></h3>
+		</div>
+		<div class="list-group scroll-box"></div>
+	</div><!-- /panel -->
+</div><!-- /col -->
+
+<script>
+$(document).on('appUpdate', function(e, lang) {
+	
+	var box = $('#localadmin-widget div.scroll-box');
+	
+	$.getJSON( appUrl + '/module/localadmin/get_localadmin', function( data ) {
+		
+		box.empty();
+		if(data.length){
+			$.each(data, function(i,d){
+				var badge = '<span class="badge pull-right">'+d.count+'</span>';
+                box.append('<a href="'+appUrl+'/show/listing/localadmin/localadmin/#'+d.users+'" class="list-group-item">'+d.users+badge+'</a>')
+			});
+		}
+		else{
+			box.append('<span class="list-group-item">'+i18n.t('localadmin.nolocaladmin')+'</span>');
+		}
+	});
+});	
+</script>

--- a/config_default.php
+++ b/config_default.php
@@ -591,22 +591,23 @@
 	| This is a list of the current dashboard widgets
 	|
 	| Small horizontal widgets:
-	|	bound_to_ds
-	|	client (two items)
-	|	external_displays_count
-	|	firmwarepw
-	|	gatekeeper
-	|	hardware_model
-	|	smart_status
-	|	disk_report
-	|	uptime
-	|	installed memory
-	|	munki
-	|	power_battery_condition
-	|	power_battery_health
-	|	sip
-	|	wifi_state
-	|
+        |       bound_to_ds
+        |       client (two items)
+        |       disk_report
+        |       external_displays_count
+        |       firmwarepw
+        |       gatekeeper
+        |       hardware_model
+        |       installed memory
+        |       localadmin
+        |       munki
+        |       power_battery_condition
+        |       power_battery_health
+        |       sip
+        |       smart_status
+        |       uptime
+        |       wifi_state
+        |       	|
 	| Small horizontal / medium vertical widgets:
 	|	network_location
 	|


### PR DESCRIPTION
Added localization
Added Listing
Added Report
Updated model and controller.


Widget shows machines that has two or more local admins on the system. Since every computer has at least one admin account this shows those that have more than one.

Added widget name to the custom_defaults.php and alphabetized the current "small horizontal" listing.