### PR TITLE
Fixed localization for media type in disk_listing (Storage Report)

### DIFF
--- a/app/modules/disk_report/locales/de.json
+++ b/app/modules/disk_report/locales/de.json
@@ -5,6 +5,7 @@
     "external": "Extern",
     "free": "Frei",
     "internal": "Intern",
+    "media_type": "Media Type",
     "mountpoint": "Mount Point",
     "not_encrypted": "Nicht verschlüsselt",
     "percentage": "Prozent",

--- a/app/modules/disk_report/locales/en.json
+++ b/app/modules/disk_report/locales/en.json
@@ -8,6 +8,7 @@
     "fusion": "Fusion",
     "hdd": "HDD",
     "internal": "Internal",
+    "media_type": "Media Type",
     "mountpoint": "Mount Point",
     "not_encrypted": "Not Encrypted",
     "percentage": "Percentage",

--- a/app/modules/disk_report/locales/fr.json
+++ b/app/modules/disk_report/locales/fr.json
@@ -5,6 +5,7 @@
     "external": "Externe",
     "free": "Libre",
     "internal": "Interne",
+    "media_type": "Media Type",
     "mountpoint": "Point de montage",
     "not_encrypted": "Non chiffré",
     "percentage": "Pourcentage",

--- a/app/modules/disk_report/views/disk_listing.php
+++ b/app/modules/disk_report/views/disk_listing.php
@@ -21,7 +21,7 @@ new Reportdata_model;
 		        <th data-i18n="serial" data-colname='reportdata.serial_number'></th>
 		        <th data-i18n="username" data-colname='reportdata.long_username'></th>
 		        <th data-i18n="disk_report.mountpoint" data-colname='diskreport.MountPoint'></th>
-		        <th data-i18n="disk_report.storage_type" data-colname='diskreport.VolumeType'></th>
+		        <th data-i18n="disk_report.media_type" data-colname='diskreport.VolumeType'></th>
 		        <th data-i18n="disk_report.percentage" data-sort='desc' data-colname='diskreport.Percentage'></th>
 		        <th data-i18n="disk_report.free" data-colname='diskreport.FreeSpace'></th>
 		        <th data-i18n="disk_report.total_size" data-colname='diskreport.TotalSize'></th>


### PR DESCRIPTION
Storage Report was missing a localization.
Added. I don't have the translations for German or French so I just added it in English.