### PR TITLE
Added path to check for config, removing dependencey on a file in the…

### DIFF
--- a/index.php
+++ b/index.php
@@ -25,11 +25,15 @@ function load_conf()
 	// Load default configuration
 	require_once(APP_ROOT . "config_default.php");
 
-	if ((include_once APP_ROOT . "config.php") !== 1)
-	{
+	if (file_exists(APP_ROOT . "config.php")) {
+		include_once(APP_ROOT . "config.php");
+	} elseif (file_exists(APP_ROOT . "/custom/config/" . "config.php")) {
+		include_once(APP_ROOT . "/custom/config/" . "config.php");
+	} else {
 		fatal(APP_ROOT. "config.php is missing!<br>
 	Unfortunately, Munkireport does not work without it</p>");
 	}
+
 
 	// Convert auth_config to config item
 	if(isset($auth_config))


### PR DESCRIPTION
… webroot. Allows for git management of custom config.php.

Since the common (preferred?) way to install munkireport is via git clone, this PR adds checking for a config.php in /custom/config/config.php as well. This will allow admins to manage a git repo on custom/config/ to version their preference file as well.

This first checks for config.php in /. If it finds it it loads and doesn't continue processing.  If the first check fails, it checks the /custom/config/ directory, if that fails then it errors out.