### PR TITLE
Touch version file when using pkg installer

### DIFF
--- a/app/views/install/install_script.php
+++ b/app/views/install/install_script.php
@@ -249,7 +249,9 @@ if [ $ERR = 0 ]; then
 		for i in "${PREF_CMDS[@]}";
 			do echo $i >> $SCRIPTDIR/postinstall
 		done
-        echo "defaults write ${PREFPATH} Version ${VERSIONLONG}" >> $SCRIPTDIR/postinstall
+
+		echo "defaults write ${PREFPATH} Version ${VERSIONLONG}" >> $SCRIPTDIR/postinstall
+		echo "touch "${MUNKIPATH}munkireport-${VERSION}"" >> $SCRIPTDIR/postinstall
 		chmod +x $SCRIPTDIR/postinstall
 
 


### PR DESCRIPTION
Previous method only touched version file in SCRIPTDIR when using the
curl method to install.