### PR TITLE
CACHEPATH added to -i option

### DIFF
--- a/app/views/install/install_script.php
+++ b/app/views/install/install_script.php
@@ -101,6 +101,7 @@ while getopts b:m:p:r:c:v:i:nh flag; do
 			INSTALLTEMP=$(mktemp -d -t mrpkg)
 			INSTALLROOT="$INSTALLTEMP"/install_root
 			MUNKIPATH="$INSTALLROOT"/usr/local/munki/
+			CACHEPATH="${MUNKIPATH}preflight.d/cache/"
 			TARGET_VOLUME='$3'
 			PREFPATH="${TARGET_VOLUME}/Library/Preferences/MunkiReport"
 			PREFLIGHT=0


### PR DESCRIPTION
Added `CACHEPATH="${MUNKIPATH}preflight.d/cache/"` to the list of variables set in the -i option.

CACHEPATH is using the local path even when creating a .pkg.  Module install.sh scripts that reference CACHEPATH would then try and affect the system that was making the pkg, not the path that should be inside the pkg.

Build runs were showing errors on the local paths:

```
bash -c "$(curl http://example.com/munkireport/index.php?/install)" bash -i ~/Desktop
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 33382    0 33382    0     0  3298k      0 --:--:-- --:--:-- --:--:-- 3622k
Preparing /var/folders/cn/92l5b1dn49z2zk_xt43n84kh0000gg/T/mrpkg.v1uu5Kqo/install_root/usr/local/munki/ and $3/Library/Preferences/MunkiReport
BaseURL is http://example/munkireport/
Retrieving munkireport scripts
Configuring munkireport
+ Installing appusage
touch: /usr/local/munki/preflight.d/cache/appusage.csv: Permission denied
+ Installing ard
+ Installing security
override rw-r--r--  root/wheel for /usr/local/munki/preflight.d/cache/security.txt? y
rm: /usr/local/munki/preflight.d/cache/security.txt: Permission denied
Building MunkiReport v2.13.0 package.
pkgbuild: Inferring bundle components from contents of /var/folders/cn/92l5b1dn49z2zk_xt43n84kh0000gg/T/mrpkg.v1uu5Kqo/install_root
pkgbuild: Adding top-level preinstall script
pkgbuild: Adding top-level postinstall script
pkgbuild: Wrote package to /Users/techhelp/Desktop/munkireport-2.13.0.pkg
Cleaning up temporary directory /var/folders/cn/92l5b1dn49z2zk_xt43n84kh0000gg/T/mrpkg.v1uu5Kqo
```

The security module install.sh referenced:

```

if [ -f "${CACHEPATH}security.txt" ]; then
	rm "${CACHEPATH}security.txt"
fi
```

and appusage uses:

```
	mkdir -p "${CACHEPATH}"
	touch "${CACHEPATH}${MODULE_CACHE_FILE}"
```

The proposed change allows for a clean run and the files that are in the CACHEPATH to be placed correctly in the install_root path.