### PR TITLE
Adjusted cache paths in module install scripts

### DIFF
--- a/app/modules/appusage/scripts/install.sh
+++ b/app/modules/appusage/scripts/install.sh
@@ -12,8 +12,8 @@ CTL="${BASEURL}index.php?/module/${MODULE_NAME}/"
 if [ $? = 0 ]; then
 	# Make executable
 	chmod a+x "${MUNKIPATH}preflight.d/appusage"
-	mkdir -p "${CACHEPATH}"
-	touch "${CACHEPATH}${MODULE_CACHE_FILE}"
+	mkdir -p "${MUNKIPATH}preflight.d/cache"
+	touch "${MUNKIPATH}preflight.d/cache/${MODULE_CACHE_FILE}"
 
 	# Set preference to include this file in the preflight check
 	setreportpref $MODULE_NAME "${CACHEPATH}${MODULE_CACHE_FILE}"

--- a/app/modules/caching/scripts/install.sh
+++ b/app/modules/caching/scripts/install.sh
@@ -13,7 +13,7 @@ CTL="${BASEURL}index.php?/module/${MODULE_NAME}/"
 if [ $? = 0 ]; then
 	# Make executable
 	chmod a+x "${MUNKIPATH}preflight.d/${MODULESCRIPT}"
-	touch "${CACHEPATH}${MODULE_CACHE_FILE}"
+	touch "${MUNKIPATH}preflight.d/cache/${MODULE_CACHE_FILE}"
 
 	# Set preference to include this file in the preflight check
 	setreportpref $MODULE_NAME "${CACHEPATH}${MODULE_CACHE_FILE}"

--- a/app/modules/certificate/scripts/install.sh
+++ b/app/modules/certificate/scripts/install.sh
@@ -2,7 +2,7 @@
 
 MODULE_NAME="certificate"
 MODULESCRIPT="cert_check"
-PREF_FILE="${CACHEPATH}certificate.txt"
+PREF_FILE="certificate.txt"
 
 CTL="${BASEURL}index.php?/module/${MODULE_NAME}/"
 
@@ -15,7 +15,7 @@ if [ $? = 0 ]; then
 	chmod a+x "${MUNKIPATH}preflight.d/${MODULESCRIPT}"
 
 	# Set preference to include this file in the preflight check
-	setreportpref $MODULE_NAME "${PREF_FILE}"
+	setreportpref $MODULE_NAME "${CACHEPATH}${PREF_FILE}"
 
 else
 	echo "Failed to download all required components!"

--- a/app/modules/security/scripts/install.sh
+++ b/app/modules/security/scripts/install.sh
@@ -11,8 +11,8 @@ if [ -f "${MUNKIPATH}preflight.d/security.sh" ]; then
 	rm "${MUNKIPATH}preflight.d/security.sh"
 fi
 
-if [ -f "${CACHEPATH}security.txt" ]; then
-	rm "${CACHEPATH}security.txt"
+if [ -f "${MUNKIPATH}preflight.d/cache/security.txt" ]; then
+	rm "${MUNKIPATH}preflight.d/cache/security.txt"
 fi
 
 

--- a/app/views/install/install_script.php
+++ b/app/views/install/install_script.php
@@ -101,7 +101,7 @@ while getopts b:m:p:r:c:v:i:nh flag; do
 			INSTALLTEMP=$(mktemp -d -t mrpkg)
 			INSTALLROOT="$INSTALLTEMP"/install_root
 			MUNKIPATH="$INSTALLROOT"/usr/local/munki/
-			TARGET_VOLUME="\$3"
+			TARGET_VOLUME='$3'
 			PREFPATH="${TARGET_VOLUME}/Library/Preferences/MunkiReport"
 			PREFLIGHT=0
 			BUILDPKG=1

--- a/app/views/install/install_script.php
+++ b/app/views/install/install_script.php
@@ -101,7 +101,7 @@ while getopts b:m:p:r:c:v:i:nh flag; do
 			INSTALLTEMP=$(mktemp -d -t mrpkg)
 			INSTALLROOT="$INSTALLTEMP"/install_root
 			MUNKIPATH="$INSTALLROOT"/usr/local/munki/
-			TARGET_VOLUME='$3'
+			TARGET_VOLUME="\$3"
 			PREFPATH="${TARGET_VOLUME}/Library/Preferences/MunkiReport"
 			PREFLIGHT=0
 			BUILDPKG=1


### PR DESCRIPTION
Build runs were showing errors on the local paths:

```
bash -c "$(curl http://example.com/munkireport/index.php?/install)" bash -i ~/Desktop
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 33382    0 33382    0     0  3298k      0 --:--:-- --:--:-- --:--:-- 3622k
Preparing /var/folders/cn/92l5b1dn49z2zk_xt43n84kh0000gg/T/mrpkg.v1uu5Kqo/install_root/usr/local/munki/ and $3/Library/Preferences/MunkiReport
BaseURL is http://example/munkireport/
Retrieving munkireport scripts
Configuring munkireport
+ Installing appusage
touch: /usr/local/munki/preflight.d/cache/appusage.csv: Permission denied
+ Installing ard
+ Installing security
override rw-r--r--  root/wheel for /usr/local/munki/preflight.d/cache/security.txt? y
rm: /usr/local/munki/preflight.d/cache/security.txt: Permission denied
Building MunkiReport v2.13.0 package.
pkgbuild: Inferring bundle components from contents of /var/folders/cn/92l5b1dn49z2zk_xt43n84kh0000gg/T/mrpkg.v1uu5Kqo/install_root
pkgbuild: Adding top-level preinstall script
pkgbuild: Adding top-level postinstall script
pkgbuild: Wrote package to /Users/techhelp/Desktop/munkireport-2.13.0.pkg
Cleaning up temporary directory /var/folders/cn/92l5b1dn49z2zk_xt43n84kh0000gg/T/mrpkg.v1uu5Kqo
```

The proposed changes allows the module to affect the correct cache paths when building a package or installing locally.