### PR TITLE
Smart stat error count table fixup

### DIFF
--- a/app/modules/smart_stats/migrations/002_smart_stats_remove_fake_null.php
+++ b/app/modules/smart_stats/migrations/002_smart_stats_remove_fake_null.php
@@ -1,0 +1,29 @@
+<?php
+
+// Remove fake nulls and set them to NULL
+
+class Migration_smart_stats_remove_fake_null extends Model
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->tablename = 'smart_stats';
+    }
+
+    public function up()
+    {
+        // Set Nulls
+         foreach (array('error_count') as $item)
+        {    
+            $sql = 'UPDATE smart_stats 
+            SET '.$item.' = NULL
+            WHERE '.$item.' = -9876543 OR '.$item.' = -9876540';
+            $this->exec($sql);
+        }   
+    }
+
+    public function down()
+    {
+        throw new Exception("Can't go back", 1);
+    }
+}

--- a/app/modules/smart_stats/smart_stats_model.php
+++ b/app/modules/smart_stats/smart_stats_model.php
@@ -126,7 +126,7 @@ class Smart_stats_model extends Model {
 
 
         // Schema version, increment when creating a db migration
-        $this->schema_version = 1;
+        $this->schema_version = 2;
 
         // Indexes to optimize queries
         $this->idx[] = array('serial_number');


### PR DESCRIPTION
Added a 2nd migration to update the `error_count` table and replace value with NULL where appropriate. This table was missed in the 001 migration.

