### PR TITLE
Moved SMART errors left in listing to be visible w/o scrolling.

### DIFF
--- a/app/modules/smart_stats/views/smart_stats_listing.php
+++ b/app/modules/smart_stats/views/smart_stats_listing.php
@@ -20,6 +20,8 @@ new Smart_stats_model;
 		      	<th data-i18n="listing.computername" data-colname='machine.computer_name'></th>
 		        <th data-i18n="serial" data-colname='reportdata.serial_number'></th>
 		        <th data-i18n="smart_stats.disk_number" data-colname='smart_stats.disk_number'></th>
+		        <th data-i18n="smart_stats.error_count" data-colname='smart_stats.error_count'></th>
+		        <th data-i18n="smart_stats.error_poh" data-colname='smart_stats.error_poh'></th>
 		        <th data-i18n="smart_stats.model_family" data-colname='smart_stats.model_family'></th>
 		        <th data-i18n="smart_stats.device_model" data-colname='smart_stats.device_model'></th>
 		        <th data-i18n="smart_stats.serial_number_hdd" data-colname='smart_stats.serial_number_hdd'></th>
@@ -30,8 +32,6 @@ new Smart_stats_model;
 		        <th data-i18n="smart_stats.sata_version_is" data-colname='smart_stats.sata_version_is'></th>
 		        <th data-i18n="smart_stats.user_capacity" data-colname='smart_stats.user_capacity'></th>
 		        <th data-i18n="smart_stats.timestamp" data-colname='smart_stats.timestamp'></th>
-		        <th data-i18n="smart_stats.error_count" data-colname='smart_stats.error_count'></th>
-		        <th data-i18n="smart_stats.error_poh" data-colname='smart_stats.error_poh'></th>
 		        <th data-i18n="smart_stats.power_on_hours" data-colname='smart_stats.power_on_hours'></th>
 		        <th data-i18n="smart_stats.power_cycle_count" data-colname='smart_stats.power_cycle_count'></th>
 		        <th data-i18n="smart_stats.reallocated_sector_ct" data-colname='smart_stats.reallocated_sector_ct'></th>
@@ -117,25 +117,25 @@ new Smart_stats_model;
 	        	var disknum=$('td:eq(2)', nRow).html();
 	        	$('td:eq(2)', nRow).html("/dev/disk"+disknum)
 
-                // Format timestamp
-                var timestamp = (($('td:eq(12)', nRow).html()) * 1000);
-                $('td:eq(12)', nRow).html(moment(timestamp).format("YYYY-MM-DD H:mm:ss"))
-                
                 // Format SMART Error Count
-	        	var status=$('td:eq(13)', nRow).html();
+	        	var status=$('td:eq(3)', nRow).html();
                 if (status != ""){
-                    $('td:eq(13)', nRow).addClass('danger').html(status)
+                    $('td:eq(3)', nRow).addClass('danger').html(status)
                 } else {
-                    $('td:eq(13)', nRow).html("")
+                    $('td:eq(3)', nRow).html("")
                 }
                 
                 // Format SMART Power On Hours Error Count
-	        	var status=$('td:eq(14)', nRow).html();
+	        	var status=$('td:eq(4)', nRow).html();
                 if (status != ""){
-                    $('td:eq(14)', nRow).addClass('danger').html(status)
+                    $('td:eq(4)', nRow).addClass('danger').html(status)
                 } else {
-                    $('td:eq(14)', nRow).html("")
+                    $('td:eq(4)', nRow).html("")
                 }
+                
+                // Format timestamp
+                var timestamp = (($('td:eq(14)', nRow).html()) * 1000);
+                $('td:eq(14)', nRow).html(moment(timestamp).format("YYYY-MM-DD H:mm:ss"))
                 
 	        	var status=$('td:eq(15)', nRow).html();
                 if (status != null){


### PR DESCRIPTION
The smart errors are most interesting at a glance, especially when highlighted red.  Even on my wide screen 27" monitor it was off to the right and required scrolling to see.
This PR moves the columns to the left so they are visible on page load w/o needing to scroll.