### PR TITLE
docs: Update default_config.php

### DIFF
--- a/config_default.php
+++ b/config_default.php
@@ -255,7 +255,7 @@
 	| $conf['bundlepath_ignorelist'][] = '/System/Library/.*';
 	|
 	| Skip all apps that are contained in an app bundle
-	| $conf['bundlepath_ignorelist'][] = '.*\.app\/.*\.app'
+	| $conf['bundlepath_ignorelist'][] = '.*\.app\/.*\.app';
 	|
 	*/
 	$conf['bundlepath_ignorelist'] = array('/System/Library/.*');


### PR DESCRIPTION
Adds a semicolon so users can copy/paste without php error.

Replaces PR: #753