### PR TITLE
Report only unique errors and warnings.

### DIFF
--- a/app/modules/munkireport/scripts/munkireport.py
+++ b/app/modules/munkireport/scripts/munkireport.py
@@ -69,8 +69,15 @@ def main():
              'Errors', 'Warnings', 'RunType']
 
     for item in items:
-        if install_report.get(item):
-            report_list[item] = install_report[item]
+        # Only list unique errors. Munki lists missing catalogs for each section: Check for installs, Check for removals, Check for managed updates
+        #  causing duplicate entries for the same catalog.
+        if item == 'Errors' or item == 'Warnings':
+            if install_report.get(item):
+                report_list[item] = list(set(install_report[item]))
+        else:
+            if install_report.get(item):
+                report_list[item] = install_report[item]
+    
     # pylint: enable=E1103
 
     if DEBUG:


### PR DESCRIPTION
Current Error reporting for the munkireport module has duplicate entries since Munki reports an error for a missing catalog during different phases of the munki run.

This PR pares the list of Errors and Warnings down to just unique entries.

On my machine I have many different testing and development catalogs for titles that aren't always in testing or production. I want the software when they are imported into munki and in those catalogs, so I leave the catalogs in the manifest.  In MR I see 40 munki errors (10 errors, 4x).  When eyeballing the Events log, having a more accurate representation of the number of errors clients are seeing would help flag actual issues.

-Eric