### PR TITLE
Adjust 'soon' to be one month instead of 3

### DIFF
--- a/app/modules/certificate/certificate_model.php
+++ b/app/modules/certificate/certificate_model.php
@@ -168,11 +168,11 @@ class Certificate_model extends Model
     public function get_stats()
     {
         $now = time();
-        $three_months = $now + 3600 * 24 * 30 * 3;
+        $one_month = $now + 3600 * 24 * 30 * 1;
         $sql = "SELECT COUNT(1) as total, 
 			COUNT(CASE WHEN cert_exp_time < '$now' THEN 1 END) AS expired, 
-			COUNT(CASE WHEN cert_exp_time BETWEEN $now AND $three_months THEN 1 END) AS soon,
-			COUNT(CASE WHEN cert_exp_time > $three_months THEN 1 END) AS ok
+			COUNT(CASE WHEN cert_exp_time BETWEEN $now AND $one_month THEN 1 END) AS soon,
+			COUNT(CASE WHEN cert_exp_time > $one_month THEN 1 END) AS ok
 			FROM certificate
 			LEFT JOIN reportdata USING (serial_number)
 			".get_machine_group_filter();

--- a/app/modules/certificate/locales/de.json
+++ b/app/modules/certificate/locales/de.json
@@ -7,8 +7,8 @@
     "issuer": "Issuer",
     "location": "Location",
     "nocertificate": "No Certificate",
-    "ok": "Gültig für mehr als drei Monate",
+    "ok": "Gültig für mehr als ein Monat",
     "report_title": "Zertifikats-Report",
-    "soon": "Läuft innerhalb der nächsten drei Monate ab",
+    "soon": "Läuft innerhalb der nächsten ein Monat ab",
     "title": "Zertifikate"
 }

--- a/app/modules/certificate/locales/en.json
+++ b/app/modules/certificate/locales/en.json
@@ -4,11 +4,11 @@
     "expired": "Expired",
     "expiration_date": "Expiration Date",
     "expires": "Expires",
-    "ok": "3 Months +",
+    "ok": "1 Month +",
     "issuer": "Issuer",
     "location": "Location",
     "nocertificate": "No Certificate",
     "report_title": "Certificate Report",
-    "soon": "< 3 Months",
+    "soon": "< 1 Month",
     "title": "Certificates"
 }

--- a/app/modules/certificate/locales/fr.json
+++ b/app/modules/certificate/locales/fr.json
@@ -7,8 +7,8 @@
     "issuer": "Issuer",
     "location": "Location",
     "nocertificate": "No Certificate",
-    "ok": "Valable pour plus de trois mois",
+    "ok": "Valable pour plus de un mois",
     "report_title": "Rapport Certificats",
-    "soon": "Expire dans les trois mois",
+    "soon": "Expire dans les un mois",
     "title": "Certificats"
 }


### PR DESCRIPTION
By default Lets Encrypt certs expire in 3 months.  With a 3 month "soon" all LE certs would perpetually be shown as expiring soon and in turn cause awareness fatigue toward the expiring soon warning.
Setting the notification of a cert expiring to 1 month would allow for time to address the expiring cert but also give notice to the admin regarding the upcoming expiration.