### PR TITLE
Set widget timeframe variable to 0 if sql search in model returns null

### DIFF
--- a/app/modules/reportdata/views/uptime_widget.php
+++ b/app/modules/reportdata/views/uptime_widget.php
@@ -47,9 +47,21 @@ $(document).on('appReady', function(e, lang) {
 	    		return;
 	    	}
 
-			panelBody.find('a.btn-success span.bigger-150').text(data.oneday);
-			panelBody.find('a.btn-warning span.bigger-150').text(data.oneweek);
-			panelBody.find('a.btn-danger span.bigger-150').text(data.oneweekplus);
+		if(data.oneday == null){
+			data.oneday = 0;
+		}
+
+                if(data.oneweek == null){
+                        data.oneweek = 0;
+                }
+
+                if(data.oneweekplus == null){
+                        data.oneweekplus = 0;
+                }
+	
+		panelBody.find('a.btn-success span.bigger-150').text(data.oneday);
+		panelBody.find('a.btn-warning span.bigger-150').text(data.oneweek);
+		panelBody.find('a.btn-danger span.bigger-150').text(data.oneweekplus);
 
 	    });
 	});

--- a/app/modules/reportdata/views/uptime_widget.php
+++ b/app/modules/reportdata/views/uptime_widget.php
@@ -13,15 +13,15 @@
 
 		<div class="panel-body text-center">
 
-			<a href="" class="btn btn-danger">
+			<a tag="oneweekplus" class="btn btn-danger disabled">
 				<span class="bigger-150"> 0 </span><br>
 				7 <span data-i18n="date.day_plural"></span> +
 			</a>
-			<a href="" class="btn btn-warning">
+			<a tag="oneweek" class="btn btn-warning disabled">
 				<span class="bigger-150"> 0 </span><br>
 				< 7 <span data-i18n="date.day_plural"></span>
 			</a>
-			<a href="" class="btn btn-success">
+			<a tag="oneday" class="btn btn-success disabled">
 				<span class="bigger-150"> 0 </span><br>
 				< 1 <span data-i18n="date.day"></span>
 			</a>
@@ -46,22 +46,11 @@ $(document).on('appReady', function(e, lang) {
 	    		//alert(data.error);
 	    		return;
 	    	}
-
-		if(data.oneday == null){
-			data.oneday = 0;
-		}
-
-                if(data.oneweek == null){
-                        data.oneweek = 0;
-                }
-
-                if(data.oneweekplus == null){
-                        data.oneweekplus = 0;
-                }
-	
-		panelBody.find('a.btn-success span.bigger-150').text(data.oneday);
-		panelBody.find('a.btn-warning span.bigger-150').text(data.oneweek);
-		panelBody.find('a.btn-danger span.bigger-150').text(data.oneweekplus);
+			$.each(['oneday', 'oneweek', 'oneweekplus'], function(i, tag){
+				panelBody.find('a[tag="'+tag+'"]')
+					.toggleClass('disabled', !data[tag])
+					.find('span.bigger-150').text(data[tag] || 0)
+			})
 
 	    });
 	});


### PR DESCRIPTION
If the timeframes for the uptime widget didn't' have any matches the value returned from the sql query was "null" and the widget displayed no value instead a definitive 0.
This checks the values of the returned data to see if it is null, if so, explicitly sets it to 0.

I'm not sure if this is the correct place to fix this so feel free to adjust as necessary.  I didn't see an easy way to return this value in the model since the values are coming straight from the sql query.