### PR TITLE
Adjust cert_exp_time to be BIGINT due to values exceeding support of INT

### DIFF
--- a/app/modules/certificate/certificate_model.php
+++ b/app/modules/certificate/certificate_model.php
@@ -7,7 +7,7 @@ class Certificate_model extends Model
         parent::__construct('id', 'certificate'); //primary key, tablename
         $this->rs['id'] = '';
         $this->rs['serial_number'] = $serial; //$this->rt['serial_number'] = 'VARCHAR(255) UNIQUE';
-        $this->rs['cert_exp_time'] = 0; // Unix timestamp of expiration time
+        $this->rs['cert_exp_time'] = 0; $this->rt['cert_exp_time'] = 'BIGINT'; // Unix timestamp of expiration time
         $this->rs['cert_path'] = ''; // Path to certificate
         $this->rs['cert_cn'] = ''; // Common name
         $this->rs['issuer'] = ''; //Certificate issuer
@@ -15,7 +15,7 @@ class Certificate_model extends Model
         $this->rs['timestamp'] = 0; // Timestamp of last update
         
         // Schema version, increment when creating a db migration
-        $this->schema_version = 1;
+        $this->schema_version = 2;
         
         //indexes to optimize queries
         $this->idx[] = array('serial_number');

--- a/app/modules/certificate/migrations/002_certificate_bigint_cert_exp_time.php
+++ b/app/modules/certificate/migrations/002_certificate_bigint_cert_exp_time.php
@@ -1,0 +1,40 @@
+<?php
+
+// Sets the cert_exp_time colum to be BIGINT
+
+class Migration_certificate_bigint_cert_exp_time extends Model
+{
+
+    
+    public function __construct()
+    {
+        parent::__construct();
+        $this->tablename = 'certificate';
+    }
+
+    public function up()
+    {
+        switch ($this->get_driver())
+        {
+            // Set column type
+            case 'sqlite':
+                     
+                break;
+
+            case 'mysql':
+                
+                    $sql = 'ALTER TABLE certificate CHANGE cert_exp_time cert_exp_time BIGINT';
+                    $this->exec($sql);
+                
+                break;
+
+            default:
+                throw new Exception("Unknown Datbase driver", 1);
+        }
+    }
+
+    public function down()
+    {
+        throw new Exception("Can't go back", 1);
+    }
+}


### PR DESCRIPTION
Errors in the certificate module from int values larger than the signed int allowed values.
This PR adds a migration to change cert_exp_time from INT to BIGINT to allow for larger values.

Tested by checking out `master`, dropping the `certificate` table, loading the listing in a browser to create the table with `cert_exp_time` set to INT and schema version 1.
Checked out this branch, reloaded the listing in the browser.  The migration succeeded per the webpage. Confirmed by observing the type for `cert_exp_time` is now BIGINT.