### PR TITLE
Update BU to sort MGs by name

### DIFF
--- a/app/views/admin/business_units.php
+++ b/app/views/admin/business_units.php
@@ -771,7 +771,12 @@
 		// Render when all requests are successful
 		defer.done(function(bu_data, mg_data, gr_data){
 
-			machineGroups = mg_data[0];
+			machineGroups = mg_data[0].sort( function( a, b ) {
+				a = a.name.toLowerCase();
+				b = b.name.toLowerCase();
+
+				return a < b ? -1 : a > b ? 1 : 0;
+			});
 
 			// Remove Loading row
 			$('#loading').hide();


### PR DESCRIPTION
on the `admin/show/business_units` page, machine groups for each business unit are ordered by their id. This makes it difficult when you have a bunch of machine groups under a business unit and are trying to verify that everything is there that needs to be. This takes the machine groups and orders them by name before going on to render them.