### PR TITLE
Remove index.php? from appUrl for cleaner URLs

### DIFF
--- a/app/views/partials/head.php
+++ b/app/views/partials/head.php
@@ -34,7 +34,7 @@
 
 	<script>
 		var baseUrl = "<?php echo conf('subdirectory'); ?>",
-			appUrl = baseUrl + 'index.php?',
+			appUrl = baseUrl.replace(/\/$/,''),
 			businessUnitsEnabled = <?php echo conf('enable_business_units') ? 'true' : 'false'; ?>;
 			isAdmin = <?php echo $_SESSION['role'] == 'admin' ? 'true' : 'false'; ?>;
 			isManager = <?php echo $_SESSION['role'] == 'manager' ? 'true' : 'false'; ?>;


### PR DESCRIPTION
This one's a super tiny change but makes use of the `mod_rewrite` rule already in the supplied `.htaccess` file.

Prior to this change, pressing the `d` hotkey would send you to your `baseUrl` + `index.php?/show/dashboard`. This is makes it so all the urls are cleaner and don't include `index.php?`.’

Any external services hard-coded to use `index.php?`-style urls will still function just fine since mod_rewrite won't touch them.