### PR TITLE
Add MG sorting in edit modal

### DIFF
--- a/app/views/admin/business_units.php
+++ b/app/views/admin/business_units.php
@@ -385,6 +385,12 @@
 					itemList
 						.empty()
 
+					items = items.sort( function( a, b ) {
+						a = a.name.toLowerCase();
+						b = b.name.toLowerCase();
+						return a < b ? -1 : a > b ? 1 : 0;
+					});
+
 					$.each(items, function(index, item){
 						itemList
 							.append($('<li>')


### PR DESCRIPTION
Finishes up #807. Machine Groups were sorted in the Business Unit listing, but when you clicked edit they were unordered in the edit modal. Oops!