### PR TITLE
Module for admin-provided munki conditions

### DIFF
--- a/app/modules/munki_conditions/README.md
+++ b/app/modules/munki_conditions/README.md
@@ -1,0 +1,14 @@
+Munki Conditions Module
+=======================
+
+Provides the results of [munki conditions](https://github.com/munki/munki/wiki/Conditional-Items), allowing admins to easily generate their own reportable datapoints without creating MunkiReport modules. Condition scripts are even easier to create using [munki-facts](https://github.com/munki/munki-facts).
+
+Admin-Provided Condition scripts are found in `/usr/local/munki/conditions`.
+The results of these scripts are stored in the 'conditions' dictionary in `/Library/Managed Installs/ManagedInstallReport.plist`
+
+The following information is stored in the munki_conditions table:
+
+For each entry in conditions:
+
+* condition_key
+* condition_value

--- a/app/modules/munki_conditions/README.md
+++ b/app/modules/munki_conditions/README.md
@@ -1,14 +1,17 @@
 Munki Conditions Module
 =======================
 
-Provides the results of [munki conditions](https://github.com/munki/munki/wiki/Conditional-Items), allowing admins to easily generate their own reportable datapoints without creating MunkiReport modules. Condition scripts are even easier to create using [munki-facts](https://github.com/munki/munki-facts).
+Provides the results of [munki conditions](https://github.com/munki/munki/wiki/Conditional-Items), allowing admins to easily generate their own reportable datapoints without creating custom MunkiReport modules. Condition scripts are even easier to create using [munki-facts](https://github.com/munki/munki-facts).
 
 Admin-Provided Condition scripts are found in `/usr/local/munki/conditions`.
-The results of these scripts are stored in the 'conditions' dictionary in `/Library/Managed Installs/ManagedInstallReport.plist`
+The results of these scripts are stored in the 'Conditions' dictionary in `/Library/Managed Installs/ManagedInstallReport.plist`.
+
+Both keys and values are truncated to 255 characters.
 
 The following information is stored in the munki_conditions table:
 
-For each entry in conditions:
-
+* serial_number
 * condition_key
 * condition_value
+
+This module is mostly based on work by clburlison, erikng, bochoven and more.

--- a/app/modules/munki_conditions/README.md
+++ b/app/modules/munki_conditions/README.md
@@ -6,7 +6,7 @@ Provides the results of [munki conditions](https://github.com/munki/munki/wiki/C
 Admin-Provided Condition scripts are found in `/usr/local/munki/conditions`.
 The results of these scripts are stored in the 'Conditions' dictionary in `/Library/Managed Installs/ManagedInstallReport.plist`.
 
-Both keys and values are truncated to 255 characters.
+Both keys and values are truncated to 65,535 characters.
 
 The following information is stored in the munki_conditions table:
 

--- a/app/modules/munki_conditions/locales/en.json
+++ b/app/modules/munki_conditions/locales/en.json
@@ -1,0 +1,6 @@
+{
+  "key": "Key",
+  "listing": "Munki Conditions",
+  "reporttitle": "Munki Conditions",
+  "value": "Value"
+}

--- a/app/modules/munki_conditions/locales/en.json
+++ b/app/modules/munki_conditions/locales/en.json
@@ -1,4 +1,5 @@
 {
+  "client_tab": "Munki Conditions",
   "key": "Key",
   "listing": "Munki Conditions",
   "reporttitle": "Munki Conditions",

--- a/app/modules/munki_conditions/munki_conditions_controller.php
+++ b/app/modules/munki_conditions/munki_conditions_controller.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * munki_conditions status module class
+ *
+ * @package munkireport
+ * @author nperkins487
+ **/
+class munki_conditions_controller extends Module_controller
+{
+    
+    protected $module_path;
+    protected $view_path;
+
+
+  /*** Protect methods with auth! ****/
+    public function __construct()
+    {
+      // Store module path
+        $this->module_path = dirname(__FILE__);
+        $this->view_path = dirname(__FILE__) . '/views/';
+    }
+  /**
+   * Default method
+   *
+   * @author
+   **/
+    public function index()
+    {
+        echo "You've loaded the munki_conditions module!";
+    }
+  
+    /**
+    * undocumented function summary
+    *
+    * Undocumented function long description
+    *
+    * @param type var Description
+    * @return {11:return type}
+    */
+    public function listing($value = '')
+    {
+        if (! $this->authorized()) {
+            redirect('auth/login');
+        }
+        $data['page'] = 'clients';
+        $data['scripts'] = array("clients/client_list.js");
+        $obj = new View();
+        $obj->view('munkiprotocol_listing', $data, $this->view_path);
+    }
+
+    /**
+     * Get munki preferences for serial_number
+     *
+     * @param string $serial serial number
+     * @author clburlison
+     **/
+    public function get_data($serial = '')
+    {
+
+        $out = array();
+        $temp = array();
+        if (! $this->authorized()) {
+            $out['error'] = 'Not authorized';
+        } else {
+            $munki_conditions = new munki_conditions_model;
+            foreach ($munki_conditions->retrieve_records($serial) as $conditions) {
+                $temp[] = $conditions->rs;
+            }
+            foreach ($temp as $value) {
+                $out[$value['munkiinfo_key']] = $value['munkiinfo_value'];
+            }
+        }
+
+        $obj = new View();
+        $obj->view('json', array('msg' => $out));
+    }
+
+} // END class default_module

--- a/app/modules/munki_conditions/munki_conditions_controller.php
+++ b/app/modules/munki_conditions/munki_conditions_controller.php
@@ -45,7 +45,7 @@ class munki_conditions_controller extends Module_controller
         $data['page'] = 'clients';
         $data['scripts'] = array("clients/client_list.js");
         $obj = new View();
-        $obj->view('munkiprotocol_listing', $data, $this->view_path);
+        $obj->view('munki_conditions_listing', $data, $this->view_path);
     }
 
     /**
@@ -67,7 +67,7 @@ class munki_conditions_controller extends Module_controller
                 $temp[] = $conditions->rs;
             }
             foreach ($temp as $value) {
-                $out[$value['munkiinfo_key']] = $value['munkiinfo_value'];
+                $out[$value['condition_key']] = $value['condition_value'];
             }
         }
 

--- a/app/modules/munki_conditions/munki_conditions_controller.php
+++ b/app/modules/munki_conditions/munki_conditions_controller.php
@@ -4,6 +4,7 @@
  *
  * @package munkireport
  * @author nperkins487
+ *
  **/
 class munki_conditions_controller extends Module_controller
 {
@@ -49,7 +50,7 @@ class munki_conditions_controller extends Module_controller
     }
 
     /**
-     * Get munki preferences for serial_number
+     * Get munki conditions for serial_number
      *
      * @param string $serial serial number
      * @author clburlison

--- a/app/modules/munki_conditions/munki_conditions_model.php
+++ b/app/modules/munki_conditions/munki_conditions_model.php
@@ -8,7 +8,9 @@ class munki_conditions_model extends Model
           $this->rs['id'] = 0;
           $this->rs['serial_number'] = $serial;
           $this->rs['condition_key'] = '';
+          $this->rt['condition_key'] = 'TEXT';
           $this->rs['condition_value'] = '';
+          $this->rt['condition_value'] = 'TEXT';
         
           // Schema version, increment when creating a db migration
           $this->schema_version = 0;

--- a/app/modules/munki_conditions/munki_conditions_model.php
+++ b/app/modules/munki_conditions/munki_conditions_model.php
@@ -1,0 +1,55 @@
+<?php
+class munki_conditions_model extends Model
+{
+
+    public function __construct($serial = '')
+    {
+          parent::__construct('id', 'munki_conditions'); //primary key, tablename
+          $this->rs['id'] = 0;
+          $this->rs['serial_number'] = $serial;
+          $this->rs['condition_key'] = '';
+          $this->rs['condition_value'] = '';
+        
+          // Schema version, increment when creating a db migration
+          $this->schema_version = 0;
+        
+          // Add indexes
+          $this->idx[] = array('serial_number');
+
+          // Create table if it does not exist
+          $this->create_table();
+            
+        if ($serial) {
+            $this->retrieve_record($serial);
+          
+            $this->serial = $serial;
+        }
+    }
+
+  /**
+   * Process data sent by postflight
+   *
+   * @param string data
+   * @author nperkins487
+   **/
+    public function process($plist)
+    {
+        require_once(APP_PATH . 'lib/CFPropertyList/CFPropertyList.php');
+        $parser = new CFPropertyList();
+        $parser->parse($plist);
+
+        $plist = $parser->toArray();
+
+        $this->deleteWhere('serial_number=?', $this->serial_number);
+            $item = array_pop($plist);
+
+            reset($item);
+        while (list($key, $val) = each($item)) {
+                $this->condition_key = $key;
+                $this->condition_value = $val;
+
+                $this->id = '';
+                $this->save();
+        }
+    }
+}

--- a/app/modules/munki_conditions/munki_conditions_model.php
+++ b/app/modules/munki_conditions/munki_conditions_model.php
@@ -30,7 +30,7 @@ class munki_conditions_model extends Model
    * Process data sent by postflight
    *
    * @param string data
-   * @author nperkins487
+   * @author erikng
    **/
     public function process($plist)
     {

--- a/app/modules/munki_conditions/provides.php
+++ b/app/modules/munki_conditions/provides.php
@@ -1,7 +1,9 @@
 <?php
 
 return array(
-    'client_tabs' => array(),
+    'client_tabs' => array(
+      'munki_conditions' => array('view' => 'client_munki_conditions_tab', 'i18n' => 'munki_conditions.client_tab'),
+    ),
     'listings' => array(
         'munki_conditions' => array('view' => 'munki_conditions_listing', 'i18n' => 'munki_conditions.listing'),
     ),

--- a/app/modules/munki_conditions/provides.php
+++ b/app/modules/munki_conditions/provides.php
@@ -1,0 +1,10 @@
+<?php
+
+return array(
+    'client_tabs' => array(),
+    'listings' => array(
+        'munki_conditions' => array('view' => 'munki_conditions_listing', 'i18n' => 'munki_conditions.listing'),
+    ),
+    'reports' => array(),
+    'widgets' => array()
+);

--- a/app/modules/munki_conditions/scripts/install.sh
+++ b/app/modules/munki_conditions/scripts/install.sh
@@ -15,7 +15,7 @@ if [ $? = 0 ]; then
   chmod a+x "${MUNKIPATH}postflight.d/${MODULESCRIPT}"
 
   # Set preference to include this file in the postflight check
-  setreportpref $MODULE_NAME "${CACHEPATH}${MODULE_CACHE_FILE}"
+  setreportpref $MODULE_NAME "${POSTFLIGHT_CACHEPATH}${MODULE_CACHE_FILE}"
 
 else
   echo "Failed to download all required components!"

--- a/app/modules/munki_conditions/scripts/install.sh
+++ b/app/modules/munki_conditions/scripts/install.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+MODULE_NAME="munki_conditions"
+MODULESCRIPT="munki_conditions.py"
+MODULE_CACHE_FILE="munki_conditions.plist"
+
+CTL="${BASEURL}index.php?/module/${MODULE_NAME}/"
+
+# Get the scripts in the proper directories
+"${CURL[@]}" "${CTL}get_script/${MODULESCRIPT}" -o "${MUNKIPATH}postflight.d/${MODULESCRIPT}"
+
+# Check exit status of curl
+if [ $? = 0 ]; then
+  # Make executable
+  chmod a+x "${MUNKIPATH}postflight.d/${MODULESCRIPT}"
+
+  # Set preference to include this file in the postflight check
+  setreportpref $MODULE_NAME "${CACHEPATH}${MODULE_CACHE_FILE}"
+
+else
+  echo "Failed to download all required components!"
+  rm -f "${MUNKIPATH}postflight.d/${MODULESCRIPT}"
+
+  # Signal that we had an error
+  ERR=1
+fi

--- a/app/modules/munki_conditions/scripts/munki_conditions.py
+++ b/app/modules/munki_conditions/scripts/munki_conditions.py
@@ -4,9 +4,17 @@ munki_conditions for munkireport
 """
 
 import os
+import json
 import plistlib
 import CoreFoundation
+from datetime import datetime
 
+class DateTimeEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, datetime):
+            return o.isoformat()
+
+        return json.JSONEncoder.default(self, o)
 
 def gather_conditions(path):
   """
@@ -23,15 +31,16 @@ def gather_conditions(path):
 
   if plist.get('Conditions'):
     for key, value in plist['Conditions'].iteritems():
-      key = key[:255]
+      key = key[:65535]
       if isinstance(value, list) and len(value) > 0:
-        conditions[key] = ', '.join([str(x) for x in value])[:255]
+        conditions[key] = json.dumps(value)[:65535]
       else:
-        conditions[key] = str(value)[:255]
+        conditions[key] = str(value)[:65535]
   else:
     print 'No conditions found.'
 
   return conditions
+
 
 def main():
   """Main"""

--- a/app/modules/munki_conditions/scripts/munki_conditions.py
+++ b/app/modules/munki_conditions/scripts/munki_conditions.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+"""
+munki_conditions for munkireport
+"""
+
+import os
+import sys
+import plistlib
+import operator
+from SystemConfiguration import SCDynamicStoreCopyConsoleUser
+
+
+MUNKIPATH = '/usr/local/munki/'
+CACHEPATH = MUNKIPATH + 'preflight.d/cache/'
+USERSESSIONSPATH = CACHEPATH + 'user_sessions.plist'
+REPORTPATH = '/Library/Managed Installs/ManagedInstallReport.plist'
+
+def gather_conditions():
+  try:
+    plist = plistlib.readPlist(REPORTPATH)
+  except:
+    print 'Could not find ManagedInstallReport.plist'
+    plist = {'Conditions': []}
+
+  conditions = {}
+
+  if plist.get('Conditions'):
+    for key, value in plist['Conditions'].iteritems():
+      if isinstance(value, list) and len(value) > 0:
+        conditions[key] = reduce((lambda x, y: x + ', ' + str(y)), value)
+      else:
+        conditions[key] = str(value)
+  else:
+    print 'No conditions found.'
+
+  return conditions
+
+def munki_conditions_report():
+  return [gather_conditions()]
+
+def main():
+  """Main"""
+  # Create cache dir if it does not exist
+  cachedir = '%s/cache' % os.path.dirname(os.path.realpath(__file__))
+  if not os.path.exists(cachedir):
+      os.makedirs(cachedir)
+
+  # Write munkiinfo report to cache
+  output_plist = os.path.join(CACHEPATH, 'munki_conditions.plist')
+  plistlib.writePlist(munki_conditions_report(), output_plist)
+
+if __name__ == '__main__':
+  main()

--- a/app/modules/munki_conditions/scripts/munki_conditions.py
+++ b/app/modules/munki_conditions/scripts/munki_conditions.py
@@ -4,21 +4,17 @@ munki_conditions for munkireport
 """
 
 import os
-import sys
 import plistlib
+import CoreFoundation
 
-#todo: get report path from preferences.
 
-CACHEPATH = '%s/cache' % os.path.dirname(os.path.realpath(__file__))
-REPORTPATH = '/Library/Managed Installs/ManagedInstallReport.plist'
-
-def gather_conditions():
+def gather_conditions(path):
   """
   Read condition keys and values from the ManagedInstallReport and process them into a
   dict of strings less than 256 characters.
   """
   try:
-    plist = plistlib.readPlist(REPORTPATH)
+    plist = plistlib.readPlist(path)
   except:
     print 'Could not find ManagedInstallReport.plist'
     return {}
@@ -41,12 +37,23 @@ def main():
   """Main"""
 
   # Create cache dir if it does not exist
-  if not os.path.exists(CACHEPATH):
-      os.makedirs(CACHEPATH)
+  cache_dir = '%s/cache' % os.path.dirname(os.path.realpath(__file__))
+  if not os.path.exists(cache_dir):
+    os.makedirs(cache_dir)
+
+  managed_install_dir = CoreFoundation.CFPreferencesCopyAppValue( "ManagedInstallDir", "ManagedInstalls")
+  managed_install_dir = managed_install_dir or '/Library/Managed Installs'
+  managed_install_report = managed_install_dir + '/ManagedInstallReport.plist'
+
+  if not os.path.exists(managed_install_report):
+    print "%s is missing." % managed_install_report
+    conditions_report = {}
+  else:
+    conditions_report = gather_conditions(managed_install_report)
 
   # Write munkiinfo report to cache
-  output_plist = os.path.join(CACHEPATH, 'munki_conditions.plist')
-  plistlib.writePlist(gather_conditions(), output_plist)
+  output_plist = os.path.join(cache_dir, 'munki_conditions.plist')
+  plistlib.writePlist(conditions_report, output_plist)
 
 if __name__ == '__main__':
   main()

--- a/app/modules/munki_conditions/scripts/munki_conditions.py
+++ b/app/modules/munki_conditions/scripts/munki_conditions.py
@@ -41,9 +41,8 @@ def munki_conditions_report():
 def main():
   """Main"""
   # Create cache dir if it does not exist
-  cachedir = '%s/cache' % os.path.dirname(os.path.realpath(__file__))
-  if not os.path.exists(cachedir):
-      os.makedirs(cachedir)
+  if not os.path.exists(CACHEPATH):
+      os.makedirs(CACHEPATH)
 
   # Write munkiinfo report to cache
   output_plist = os.path.join(CACHEPATH, 'munki_conditions.plist')

--- a/app/modules/munki_conditions/scripts/uninstall.sh
+++ b/app/modules/munki_conditions/scripts/uninstall.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 rm -f "${MUNKIPATH}postflight.d/munki_conditions.py"
-rm -f "${CACHEPATH}munki_conditions.plist"
+rm -f "${MUNKIPATH}postflight.d/cache/munki_conditions.plist"

--- a/app/modules/munki_conditions/scripts/uninstall.sh
+++ b/app/modules/munki_conditions/scripts/uninstall.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+rm -f "${MUNKIPATH}postflight.d/munki_conditions.py"
+rm -f "${CACHEPATH}munki_conditions.plist"

--- a/app/modules/munki_conditions/views/client_munki_conditions_tab.php
+++ b/app/modules/munki_conditions/views/client_munki_conditions_tab.php
@@ -29,7 +29,7 @@ $(document).on('appReady', function(e, lang) {
       // Add data
       for (var key in data) {
         var element = '<tr><th>' + key + '</th><td>' + data[key] + '</td></tr>'
-        $('tbody').append(element)
+        $('#munki_conditions-table tbody').append(element)
       }
     }
 

--- a/app/modules/munki_conditions/views/client_munki_conditions_tab.php
+++ b/app/modules/munki_conditions/views/client_munki_conditions_tab.php
@@ -6,8 +6,8 @@
     <div class="col-md-7">
       <table id="#munki_conditions-table" class="table table-striped">
         <tr>
-          <th data-i18n="munki_conditions-condition_key"></th>
-          <td id="munki_conditions-condition_value"></td>
+          <th data-i18n="munki_conditions.key"></th>
+          <th data-i18n="munki_conditions.value"></th>
         </tr>
       </table>
     </div>
@@ -15,28 +15,25 @@
 
 <script>
 $(document).on('appReady', function(e, lang) {
-  
+
   // Get munki_conditions data
   $.getJSON( appUrl + '/module/munki_conditions/get_data/' + serialNumber, function( data ) {
     if( Object.keys(data).length === 0 ){
       $('#munki_conditions-msg').text(i18n.t('No Munki Condition Data Found!'));
     }
     else{
-      
       // Hide
       $('#munki_conditions-msg').text('');
       $('#munki_conditions-view').removeClass('hide');
                   
       // Add data
       for (var key in data) {
-        $('#munki_conditions-table').append('<tr><th>' + key + '</th><td>' + data[key] + '</td></tr>')
+        var element = '<tr><th>' + key + '</th><td>' + data[key] + '</td></tr>'
+        $('tbody').append(element)
       }
     }
 
-  // });
-
-  document.write(data);
-     
+  });
 });
-    
+  
 </script>

--- a/app/modules/munki_conditions/views/client_munki_conditions_tab.php
+++ b/app/modules/munki_conditions/views/client_munki_conditions_tab.php
@@ -4,7 +4,7 @@
   
   <div id="munki_conditions-view" class="row hide">
     <div class="col-md-7">
-      <table id="#munki_conditions-table" class="table table-striped">
+      <table id="munki_conditions-table" class="table table-striped">
         <tr>
           <th data-i18n="munki_conditions.key"></th>
           <th data-i18n="munki_conditions.value"></th>

--- a/app/modules/munki_conditions/views/client_munki_conditions_tab.php
+++ b/app/modules/munki_conditions/views/client_munki_conditions_tab.php
@@ -1,0 +1,42 @@
+<h2 data-i18n="munki_conditions.client_tab"></h2>
+  
+<div id="munki_conditions-msg" data-i18n="listing.loading" class="col-lg-12 text-center"></div>
+  
+  <div id="munki_conditions-view" class="row hide">
+    <div class="col-md-7">
+      <table id="#munki_conditions-table" class="table table-striped">
+        <tr>
+          <th data-i18n="munki_conditions-condition_key"></th>
+          <td id="munki_conditions-condition_value"></td>
+        </tr>
+      </table>
+    </div>
+  </div>
+
+<script>
+$(document).on('appReady', function(e, lang) {
+  
+  // Get munki_conditions data
+  $.getJSON( appUrl + '/module/munki_conditions/get_data/' + serialNumber, function( data ) {
+    if( Object.keys(data).length === 0 ){
+      $('#munki_conditions-msg').text(i18n.t('No Munki Condition Data Found!'));
+    }
+    else{
+      
+      // Hide
+      $('#munki_conditions-msg').text('');
+      $('#munki_conditions-view').removeClass('hide');
+                  
+      // Add data
+      for (var key in data) {
+        $('#munki_conditions-table').append('<tr><th>' + key + '</th><td>' + data[key] + '</td></tr>')
+      }
+    }
+
+  // });
+
+  document.write(data);
+     
+});
+    
+</script>

--- a/app/modules/munki_conditions/views/munki_conditions_listing.php
+++ b/app/modules/munki_conditions/views/munki_conditions_listing.php
@@ -1,0 +1,108 @@
+<?php $this->view('partials/head'); ?>
+
+<?php //Initialize models needed for the table
+new Machine_model;
+new Reportdata_model;
+new Munki_conditions_model;
+?>
+
+<div class="container">
+  <div class="row">
+    <div class="col-lg-12">
+      <h3><span data-i18n="munki_conditions.reporttitle"></span> <span id="total-count" class='label label-primary'>…</span></h3>
+      
+      <table class="table table-striped table-condensed table-bordered">
+        <thead>
+          <tr>
+            <th data-i18n="listing.computername" data-colname='machine.computer_name'></th>
+            <th data-i18n="serial" data-colname='reportdata.serial_number'></th>
+            <th data-i18n="username" data-colname='reportdata.long_username'></th>
+            <th data-i18n="munki_conditions.key" data-colname='munki_conditions.condition_key'></th>
+            <th data-i18n="munki_conditions.value" data-colname='munki_conditions.condition_value'></th>
+                <th data-i18n="last_seen" data-sort="desc" data-colname='reportdata.timestamp'></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+          <td data-i18n="listing.loading" colspan="6" class="dataTables_empty"></td>
+        </tr>
+        </tbody>
+      </table>
+    </div> <!-- /span 12 -->
+  </div> <!-- /row -->
+</div>  <!-- /container -->
+
+<script type="text/javascript">
+
+  $(document).on('appUpdate', function(e){
+
+    var oTable = $('.table').DataTable();
+    oTable.ajax.reload();
+    return;
+
+  }); 
+
+  $(document).on('appReady', function(e, lang) {
+
+        // Get modifiers from data attribute
+        var mySort = [], // Initial sort
+            hideThese = [], // Hidden columns
+            col = 0, // Column counter
+            runtypes = [], // Array for runtype column 
+            columnDefs = [{ visible: false, targets: hideThese }]; //Column Definitions
+
+        $('.table th').map(function(){
+
+            columnDefs.push({name: $(this).data('colname'), targets: col});
+
+            if($(this).data('sort')){
+              mySort.push([col, $(this).data('sort')])
+            }
+
+            if($(this).data('hide')){
+              hideThese.push(col);
+            }
+
+            col++
+        });
+
+      oTable = $('.table').dataTable( {
+            ajax: {
+                url: appUrl + '/datatables/data',
+                type: "POST",
+                data: function(d){
+                    
+                    // Look for a bigger/smaller/equal statement
+                    if(d.search.value.match(/^protocol = .+$/))
+                    {
+                        // Add column specific search
+                        d.columns[3].search.value = d.search.value.replace(/.*= (.+)$/, '$1');
+                        // Clear global search
+                        d.search.value = '';
+                        console.log(d.columns[3].search.value)
+                    }
+                }
+            },
+            dom: mr.dt.buttonDom,
+            buttons: mr.dt.buttons,
+            order: mySort,
+            columnDefs: columnDefs,
+        createdRow: function( nRow, aData, iDataIndex ) {
+            // Update name in first column to link
+            var name=$('td:eq(0)', nRow).html();
+            if(name == ''){name = "No Name"};
+            var sn=$('td:eq(1)', nRow).html();
+                var link = mr.getClientDetailLink(name, sn, '#tab_munki');
+                $('td:eq(0)', nRow).html(link);
+
+                // Format date
+                var checkin = parseInt($('td:eq(5)', nRow).html());
+                var date = new Date(checkin * 1000);
+                $('td:eq(5)', nRow).html(moment(date).fromNow());
+            }
+      });
+
+  });
+</script>
+
+<?php $this->view('partials/foot'); ?>


### PR DESCRIPTION
resolve #627 from @flammable.
resolve #835 from @flammable.

Please let me know if you have any suggestions.

For one, I didn't know how to get the location of ManagedInstallReport.plist from prefs so it is hardcoded in the client script.

Second, all values are truncated and stored as 255 character strings. Would it be preferred to utilize BLOB so that JSON could be used to store arrays?

Munki Conditions Module
=======================

Provides the results of [munki conditions](https://github.com/munki/munki/wiki/Conditional-Items), allowing admins to easily generate their own reportable datapoints without creating custom MunkiReport modules. Condition scripts are even easier to create using [munki-facts](https://github.com/munki/munki-facts).

Admin-Provided Condition scripts are found in `/usr/local/munki/conditions`.
The results of these scripts are stored in the 'Conditions' dictionary in `/Library/Managed Installs/ManagedInstallReport.plist`.

Both keys and values are truncated to 255 characters.

The following information is stored in the munki_conditions table:

* serial_number
* condition_key
* condition_value

This module is mostly based on work by clburlison, erikng, bochoven and more.

![screen shot 2017-08-03 at 12 12 40 am](https://user-images.githubusercontent.com/10337495/28910226-c4c9b520-77e0-11e7-9c53-f73bf2560315.png)
![screen shot 2017-08-03 at 12 12 55 am](https://user-images.githubusercontent.com/10337495/28910235-ca10a052-77e0-11e7-86eb-314d47b56359.png)
