### PR TITLE
Munki protocol widget fix

### DIFF
--- a/app/modules/munkiinfo/views/munkiinfo_munkiprotocol_widget.php
+++ b/app/modules/munkiinfo/views/munkiinfo_munkiprotocol_widget.php
@@ -20,13 +20,19 @@ $(document).on('appUpdate', function(e, lang) {
 	}
 
 		var panel = $('#munkiinfo-munkiprotocol-widget div.panel-body'),
-			baseUrl = appUrl + '/show/listing/munkiinfo/munkiinfo#munkiprotocol';
+			baseUrl = appUrl + '/show/listing/munkiinfo/munkiinfo';
 		panel.empty();
 
 		// Set statuses
-		panel.append(' <a href="'+baseUrl+'#protocol = http" class="btn btn-danger"><span class="bigger-150">'+data.http+'</span><br>&nbsp;'+i18n.t('munkiinfo.munkiprotocol.http')+'&nbsp;</a>');
-		panel.append(' <a href="'+baseUrl+'#protocol = https" class="btn btn-success"><span class="bigger-150">'+data.https+'</span><br>&nbsp;'+i18n.t('munkiinfo.munkiprotocol.https')+'&nbsp;</a>');
-		panel.append(' <a href="'+baseUrl+'" class="btn btn-info"><span class="bigger-150">'+data.localrepo+'</span><br>'+i18n.t('munkiinfo.munkiprotocol.localrepo')+'</a>');
+		if(data.http){
+		panel.append(' <a href="'+baseUrl+'#munkiprotocol" class="btn btn-danger"><span class="bigger-150">'+data.http+'</span><br>&nbsp;'+i18n.t('munkiinfo.munkiprotocol.http')+'&nbsp;</a>');
+		}
+		if(data.https){
+		panel.append(' <a href="'+baseUrl+'#munkiprotocol" class="btn btn-success"><span class="bigger-150">'+data.https+'</span><br>&nbsp;'+i18n.t('munkiinfo.munkiprotocol.https')+'&nbsp;</a>');
+		}
+		if(data.localrepo){
+		panel.append(' <a href="'+baseUrl+'#munkiprotocol" class="btn btn-info"><span class="bigger-150">'+data.localrepo+'</span><br>'+i18n.t('munkiinfo.munkiprotocol.localrepo')+'</a>');
+		}
 
     });
 });

--- a/app/modules/munkiinfo/views/munkiinfo_munkiprotocol_widget.php
+++ b/app/modules/munkiinfo/views/munkiinfo_munkiprotocol_widget.php
@@ -34,7 +34,7 @@ $(document).on('appReady', function(){
 	// Set url
 	$.each(tags, function(i, tag){
 		$('#munkiinfo-munkiprotocol-widget a[tag="'+tag+'"]')
-			.attr('href', appUrl + '/show/listing/munkiinfo/munkiinfo/#'+tag);
+			.attr('href', appUrl + '/show/listing/munkiinfo/munkiinfo/#munkiprotocol');
 	});
 
 	$(document).on('appUpdate', function(){

--- a/app/modules/munkiinfo/views/munkiinfo_munkiprotocol_widget.php
+++ b/app/modules/munkiinfo/views/munkiinfo_munkiprotocol_widget.php
@@ -11,11 +11,11 @@
             <span class="bigger-150"> 0 </span><br>
             <span data-i18n="munkiinfo.munkiprotocol.http"></span>
         </a>
-        <a tag="https" class="btn btn-warning disabled">
+        <a tag="https" class="btn btn-success disabled">
             <span class="bigger-150"> 0 </span><br>
             <span data-i18n="munkiinfo.munkiprotocol.https"></span>
         </a>
-        <a tag="localrepo" class="btn btn-success disabled">
+        <a tag="localrepo" class="btn btn-info disabled">
             <span class="bigger-150"> 0 </span><br>
             <span data-i18n="munkiinfo.munkiprotocol.localrepo"></span>
         </a>

--- a/app/modules/munkiinfo/views/munkiinfo_munkiprotocol_widget.php
+++ b/app/modules/munkiinfo/views/munkiinfo_munkiprotocol_widget.php
@@ -6,36 +6,56 @@
 	        <list-link data-url="/show/listing/munkireport/munki"></list-link>
 	    </h3>
 	  </div>
-	  <div class="panel-body text-center"></div>
+	  <div class="panel-body text-center">
+        <a tag="http" class="btn btn-danger disabled">
+            <span class="bigger-150"> 0 </span><br>
+            <span data-i18n="munkiinfo.munkiprotocol.http"></span>
+        </a>
+        <a tag="https" class="btn btn-warning disabled">
+            <span class="bigger-150"> 0 </span><br>
+            <span data-i18n="munkiinfo.munkiprotocol.https"></span>
+        </a>
+        <a tag="localrepo" class="btn btn-success disabled">
+            <span class="bigger-150"> 0 </span><br>
+            <span data-i18n="munkiinfo.munkiprotocol.localrepo"></span>
+        </a>
+	  </div>
 	</div><!-- /panel -->
 </div><!-- /col -->
 
 <script>
-$(document).on('appUpdate', function(e, lang) {
+$(document).on('appReady', function(){
 
-    $.getJSON( appUrl + '/module/munkiinfo/get_protocol_stats', function( data ) {
-	if(data.error){
-		//alert(data.error);
-		return;
-	}
+	var panelBody = $('#munkiinfo-munkiprotocol-widget div.panel-body');
 
-		var panel = $('#munkiinfo-munkiprotocol-widget div.panel-body'),
-			baseUrl = appUrl + '/show/listing/munkiinfo/munkiinfo';
-		panel.empty();
+	// Tags
+	var tags = ['http', 'https', 'localrepo'];
 
-		// Set statuses
-		if(data.http){
-		panel.append(' <a href="'+baseUrl+'#munkiprotocol" class="btn btn-danger"><span class="bigger-150">'+data.http+'</span><br>&nbsp;'+i18n.t('munkiinfo.munkiprotocol.http')+'&nbsp;</a>');
-		}
-		if(data.https){
-		panel.append(' <a href="'+baseUrl+'#munkiprotocol" class="btn btn-success"><span class="bigger-150">'+data.https+'</span><br>&nbsp;'+i18n.t('munkiinfo.munkiprotocol.https')+'&nbsp;</a>');
-		}
-		if(data.localrepo){
-		panel.append(' <a href="'+baseUrl+'#munkiprotocol" class="btn btn-info"><span class="bigger-150">'+data.localrepo+'</span><br>'+i18n.t('munkiinfo.munkiprotocol.localrepo')+'</a>');
-		}
+	// Set url
+	$.each(tags, function(i, tag){
+		$('#munkiinfo-munkiprotocol-widget a[tag="'+tag+'"]')
+			.attr('href', appUrl + '/show/listing/munkiinfo/munkiinfo/#'+tag);
+	});
 
-    });
+	$(document).on('appUpdate', function(){
+
+		$.getJSON( appUrl + '/module/munkiinfo/get_protocol_stats', function( data ) {
+
+			$.each(tags, function(i, tag){
+				// Set count
+				$('#munkiinfo-munkiprotocol-widget a[tag="'+tag+'"]')
+					.toggleClass('disabled', ! data[tag])
+					.find('span.bigger-150')
+						.text(+data[tag]);
+				// Set localized label
+				$('#munkiinfo-munkiprotocol-widget a[tag="'+tag+'"] span.count')
+					.text(i18n.t(tag, { count: +data[tag] }));
+			});
+
+		});
+
+	});
+
 });
-
 
 </script>


### PR DESCRIPTION
Two changes:

1) Adjusted the search criteria when buttons are pressed in the widget.  Previously it was trying to search for 'munkiprotocol' and 'https' for example but that would result in 0 hits since that data is across two columns.  I adjusted the search to just look for 'munkiprotocol'
2) Re-worked the buttons to be grayed out if no data is present for that criteria.