### PR TITLE
Updated SVG icon for Safari Pinned Tab. Resolved "Tombstone" Icon

### DIFF
--- a/assets/images/favicons/safari-pinned-tab.svg
+++ b/assets/images/favicons/safari-pinned-tab.svg
@@ -10,13 +10,13 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="343.68338mm"
-   height="361.95663mm"
-   viewBox="0 0 343.68338 361.95664"
+   width="1300"
+   height="1300"
+   viewBox="0 0 343.95833 343.95835"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91+devel+osxmenu r12889"
-   sodipodi:docname="munkireportphp-safaripinnedtab.svg">
+   inkscape:version="0.91+devel+osxmenu r12922"
+   sodipodi:docname="safari-pinned-tab.svg">
   <defs
      id="defs4">
     <linearGradient
@@ -179,14 +179,14 @@
        x2="0"
        y1="16.190001" />
     <filter
-       y="-0.15"
+       y="-0.15000001"
        height="1.3"
-       x="-0.15"
+       x="-0.15000001"
        width="1.3"
        inkscape:menu-tooltip="Aquarelle paper effect which can be used for pictures as for objects"
        inkscape:menu="Textures"
        inkscape:label="Rough Paper"
-       style="color-interpolation-filters:sRGB;"
+       style="color-interpolation-filters:sRGB"
        id="filter3845">
       <feTurbulence
          type="fractalNoise"
@@ -204,7 +204,7 @@
          result="result3"
          id="feDisplacementMap3849" />
       <feDiffuseLighting
-         lighting-color="rgb(233,230,215)"
+         lighting-color="#e9e6d7"
          diffuseConstant="1"
          surfaceScale="2"
          result="result1"
@@ -226,7 +226,10 @@
          result="result5"
          operator="arithmetic"
          k1="1.7"
-         id="feComposite3857" />
+         id="feComposite3857"
+         k2="0"
+         k3="0"
+         k4="0" />
       <feBlend
          in="result5"
          in2="result3"
@@ -238,10 +241,10 @@
        inkscape:menu="Textures"
        inkscape:menu-tooltip="Inkblot on blotting paper"
        height="1.3"
-       y="-0.15"
+       y="-0.15000001"
        width="1.3"
-       x="-0.15"
-       style="color-interpolation-filters:sRGB;"
+       x="-0.15000001"
+       style="color-interpolation-filters:sRGB"
        id="filter4680">
       <feGaussianBlur
          stdDeviation="3"
@@ -280,14 +283,15 @@
          k2="0.25"
          k3="1"
          k1="1"
-         id="feComposite4692" />
+         id="feComposite4692"
+         k4="0" />
       <feComposite
          operator="in"
          in2="result2"
          id="feComposite4694" />
     </filter>
     <filter
-       style="color-interpolation-filters:sRGB;"
+       style="color-interpolation-filters:sRGB"
        inkscape:label="Drop Shadow"
        id="filter4760">
       <feFlood
@@ -326,21 +330,22 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="0.3531951"
-     inkscape:cx="422.4735"
-     inkscape:cy="767.02092"
+     inkscape:zoom="0.40679261"
+     inkscape:cx="-306.93299"
+     inkscape:cy="737.58817"
      inkscape:document-units="mm"
-     inkscape:current-layer="g8485"
+     inkscape:current-layer="g8503"
      showgrid="false"
-     inkscape:window-width="1280"
-     inkscape:window-height="681"
+     inkscape:window-width="1920"
+     inkscape:window-height="963"
      inkscape:window-x="0"
      inkscape:window-y="22"
      inkscape:window-maximized="0"
      fit-margin-top="0"
      fit-margin-left="0"
      fit-margin-right="0"
-     fit-margin-bottom="0" />
+     fit-margin-bottom="0"
+     units="px" />
   <metadata
      id="metadata7">
     <rdf:RDF>
@@ -349,7 +354,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -357,355 +362,57 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(-92.281245,156.33347)">
+     transform="translate(-92.281245,138.33519)">
     <g
        id="1"
        transform="matrix(0.39124635,0,0,0.39124635,48.50424,110.66993)" />
     <g
-       transform="matrix(8.0328101,0,0,7.7012518,71.335479,-160.18627)"
-       id="g8503"
-       inkscape:export-xdpi="36.490559"
-       inkscape:export-ydpi="36.490559"
-       style="stroke:#000000;stroke-opacity:1;fill:#ffffff;stroke-width:0.38142297;stroke-miterlimit:4;stroke-dasharray:none;fill-opacity:1">
-      <path
-         style="opacity:0.8;fill:#ffffff;stroke:#000000;stroke-opacity:1;stroke-width:0.40685706;stroke-miterlimit:4;stroke-dasharray:none;fill-opacity:1"
-         inkscape:connector-curvature="0"
-         d="m 47.345411,47.231407 a 23.442127,1.9983453 0 1 1 -46.88425415,0 23.442127,1.9983453 0 1 1 46.88425415,0 z"
-         transform="matrix(0.9125654,0,0,0.963088,2.1866908,0.08741362)"
-         id="L" />
-      <path
-         style="fill:#ffffff;fill-rule:evenodd;stroke:#000000;stroke-width:0.40120878;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;fill-opacity:1"
-         inkscape:connector-curvature="0"
-         d="m 7.40625,2.875 c -0.7554285,0 -1.375,0.7312174 -1.375,1.59375 l 0,41.0625 c 0,0.862533 0.6195719,1.593749 1.375,1.59375 l 33.1875,0 c 0.755428,0 1.374999,-0.731215 1.375,-1.59375 l 0,-41.0625 c 0,-0.8625327 -0.619571,-1.59375 -1.375,-1.59375 l -33.1875,0 z"
-         transform="matrix(0.9593462,0,0,0.942101,0.9756909,1.1222877)"
-         id="M" />
-      <path
-         style="fill:#ffffff;stroke:#000000;stroke-opacity:1;stroke-width:0.38142297;stroke-miterlimit:4;stroke-dasharray:none;fill-opacity:1"
-         inkscape:connector-curvature="0"
-         d="m 11.329596,44.230313 c -1.5391991,0 -2.7727366,-1.233537 -2.7727366,-2.772736 l 0,-33.3008434 c 0,-1.5391995 1.2335375,-2.7727371 2.7727366,-2.7727361 l 25.374739,0 c 1.539199,0 2.772737,1.2335375 2.772737,2.7727361 l 0,29.7719064 -6.049608,6.301673 -22.097868,0 0,0 z"
-         id="P" />
-      <path
-         style="fill:#ffffff;stroke:#000000;stroke-opacity:1;stroke-width:0.38142297;stroke-miterlimit:4;stroke-dasharray:none;fill-opacity:1"
-         inkscape:connector-curvature="0"
-         d="m 11.329596,43.306068 c -1.038393,0 -1.8484909,-0.810098 -1.8484909,-1.848491 l 0,-33.3008434 c 0,-1.0383938 0.8100979,-1.8484924 1.8484909,-1.8484914 l 25.374739,0 c 1.038393,0 1.848491,0.8100995 1.848491,1.8484914 l 0,29.3798024 -5.517466,5.769532 -21.705764,0 z"
-         id="Q" />
-      <path
-         style="opacity:0.16000001;fill:#ffffff;filter:url(#8-5);stroke:#000000;stroke-opacity:1;stroke-width:0.44765362;stroke-miterlimit:4;stroke-dasharray:none;fill-opacity:1"
-         inkscape:connector-curvature="0"
-         d="m 77.133371,16.968067 0,6.875 c 0,0.956611 0.676661,1.593751 1.71875,1.59375 l 6.25,0 0,-1.8125 -6.9375,-6.65625 -1.03125,0 0,0 z"
-         transform="matrix(0.896238,0,0,-0.8100394,-37.71893,56.964667)"
-         id="T" />
-      <path
-         style="fill:#ffffff;stroke:#000000;stroke-opacity:1;stroke-width:0.38142297;stroke-miterlimit:4;stroke-dasharray:none;fill-opacity:1"
-         inkscape:connector-curvature="0"
-         d="m 32.194916,44.127263 0,-5.657503 c -2e-6,-1.038393 0.810097,-1.848491 1.848491,-1.84849 l 5.433443,0 0,1.204319 -6.049607,6.301674 -1.232327,0 0,0 z"
-         id="U" />
-      <path
-         style="fill:#ffffff;stroke:#000000;stroke-opacity:1;stroke-width:0.38142297;stroke-miterlimit:4;stroke-dasharray:none;fill-opacity:1"
-         inkscape:connector-curvature="0"
-         d="m 33.091375,43.10639 0,-4.733258 c -10e-7,-0.574219 0.378033,-0.952253 0.952254,-0.952252 l 4.481189,0 -5.433443,5.68551 0,0 z"
-         id="V" />
+       id="g3458">
       <g
-         transform="matrix(0.9180102,0,0,0.7524892,1.9677556,0.3657735)"
-         id="X"
-         style="stroke:#000000;stroke-opacity:1;fill:#ffffff;stroke-width:0.45891574;stroke-miterlimit:4;stroke-dasharray:none;fill-opacity:1">
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.79901736;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:export-ydpi="36.490559"
+         inkscape:export-xdpi="36.490559"
+         id="g8503"
+         transform="matrix(7.8683104,0,0,7.1665244,75.618223,-137.39699)">
         <path
-           style="fill:#ffffff;stroke:#000000;stroke-opacity:1;stroke-width:0.52174536;stroke-miterlimit:4;stroke-dasharray:none;fill-opacity:1"
+           style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.8136633;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 14.389179,3.9534503 -6.3083303,0 c -0.7247175,0 -1.319101,0.7143663 -1.319101,1.5570217 l 0,40.116207 c 0,0.842655 0.5943839,1.55702 1.319101,1.557021 l 31.8383023,0 c 0.724717,0 1.3191,-0.714364 1.319101,-1.557021 l 0,-40.116207 c 0,-0.8426555 -0.594383,-1.5570217 -1.319101,-1.5570217 l -6.283579,0"
+           id="M"
            inkscape:connector-curvature="0"
-           d="m 53.96875,16.40625 c -0.227234,0.03412 -1.169585,0.322383 -1.6875,0.96875 -0.508043,0.633965 -0.640226,0.979171 -0.5625,1.8125 0.02228,0.238917 0.08782,0.486655 0.15625,0.65625 0.03422,0.0848 0.04294,0.150533 0.0625,0.1875 l 2.09375,6.25 c 0.414131,1.259146 1.427962,1.752395 2.5,1.75 l 15.59375,0 c 1.145925,0.0026 2.091442,-0.539085 2.5,-1.78125 l 2.15625,-6.40625 C 76.877759,19.556327 76.99918,19.123868 76.9375,18.625 76.87582,18.126132 76.621473,17.629376 76.28125,17.25 75.923221,16.850594 75.438162,16.544609 75,16.4375 74.561838,16.330391 74.171214,16.406634 74.28125,16.40625 l -19.75,0 -0.125,0 c -0.01061,-7.09e-4 -0.02063,5.67e-4 -0.03125,0 -0.04246,-0.0023 -0.0825,0 -0.125,0 -0.05313,0 -0.103206,-0.0035 -0.15625,0 a 1.4526884,1.4526884 0 0 0 -0.125,0 z"
-           transform="matrix(0.879578,0,0,0.879578,-32.568236,-14.229)"
-           id="q" />
+           sodipodi:nodetypes="cssssssssc" />
         <path
-           style="fill:#ffffff;stroke:#000000;stroke-opacity:1;stroke-width:0.52174536;stroke-miterlimit:4;stroke-dasharray:none;fill-opacity:1"
+           id="P"
+           d="m 33.001485,5.5640805 3.70285,0 c 1.539199,0 2.772737,1.2791732 2.772737,2.8753157 l 0,30.8733428 -6.049608,6.534808 -22.097868,0 c -1.5391991,0 -2.7727366,-1.279172 -2.7727366,-2.875315 l 0,-34.5328358 c 0,-1.5961434 1.2335375,-2.8753168 2.7727366,-2.8753157 l 3.65637,0"
            inkscape:connector-curvature="0"
-           d="m 54.1875,17.84375 c -0.23626,0.03548 -0.487536,0.07094 -0.78125,0.4375 -0.169064,0.210968 -0.268989,0.577663 -0.25,0.78125 0.01899,0.203587 0.08524,0.287616 0.09375,0.3125 l 2.15625,6.40625 c 0.0048,0.0146 0.02578,0.017 0.03125,0.03125 0.182908,0.477016 0.696142,0.782138 1.09375,0.78125 l 15.59375,0 c 0.397612,8.88e-4 0.910837,-0.304231 1.09375,-0.78125 l 0.03125,0 c 0.0029,-0.0081 -0.0027,-0.02309 0,-0.03125 L 75.40625,19.375 c 0.125813,-0.374698 0.156742,-0.737546 -0.21875,-1.15625 -0.402647,-0.449181 -0.729514,-0.375617 -0.90625,-0.375 l -19.90625,0 c -0.0093,1.44e-4 -0.02192,1.44e-4 -0.03125,0 0.007,-5.4e-5 -0.03824,-5.4e-5 -0.03125,0 a 0.93763029,0.93763029 0 0 0 -0.125,0 z"
-           transform="matrix(0.879578,0,0,0.879578,-32.576961,-14.229)"
-           id="r" />
+           style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.8136633;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           sodipodi:nodetypes="csscccsssc" />
         <path
-           style="opacity:0.8;fill:#ffffff;stroke:#000000;stroke-width:0.52174536;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;fill-opacity:1"
+           style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.8136633;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 31.949949,44.292751 -20.225936,0 c -1.006113,0 -1.7910258,-0.813952 -1.7910258,-1.857286 l 0,-33.4593012 c 0,-1.0433348 0.7849128,-1.8572882 1.7910258,-1.8572872 l 3.92217,0 m 16.75074,0 3.912995,0 c 1.006112,0 1.791026,0.8139542 1.791026,1.8572872 l 0,28.9313212"
+           id="Q"
            inkscape:connector-curvature="0"
-           d="M 54.28125,18.625 C 54.19118,18.63853 54.082207,18.67865 54,18.78125 c -0.04601,0.05741 -0.03664,0.129698 -0.03125,0.1875 0.0044,0.04669 0.0209,0.0957 0.03125,0.125 l 0,0.03125 2.15625,6.40625 c 0.0536,0.162973 0.207402,0.281624 0.375,0.28125 l 15.59375,0 c 0.167596,3.75e-4 0.321397,-0.118276 0.375,-0.28125 l 2.15625,-6.4375 c 0.04088,-0.121739 0.03423,-0.23589 -0.0625,-0.34375 -0.100933,-0.112598 -0.213867,-0.125344 -0.3125,-0.125 l -19.90625,0 c -0.0125,1.93e-4 -0.01875,1.93e-4 -0.03125,0 -0.0044,3.5e-5 -0.02681,3.5e-5 -0.03125,0 a 0.14577079,0.14577079 0 0 0 -0.03125,0 z"
-           transform="matrix(0.879578,0,0,0.879578,-32.583902,-14.229)"
-           id="s" />
-      </g>
-    </g>
-    <g
-       id="g4638">
-      <g
-         transform="matrix(0.78973435,-0.21160869,0.18462341,0.689024,88.734412,24.466421)"
-         id="g8801">
+           sodipodi:nodetypes="cssssccssc" />
+        <path
+           id="U"
+           d="m 32.194916,45.740685 0,-5.866807 c -2e-6,-1.076809 0.810097,-1.916877 1.848491,-1.916876 l 5.433443,0 0,1.248873 -6.049607,6.53481 -1.232327,0 0,0 z"
+           inkscape:connector-curvature="0"
+           style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.8136633;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <g
-           style="opacity:1"
-           transform="translate(23.723033,24.536982)"
-           id="g8857">
-          <g
-             style="opacity:1"
-             id="g8886"
-             transform="translate(0.01408785,0.53200442)">
-            <g
-               id="g8888">
-              <ellipse
-                 ry="22.712587"
-                 rx="32.406433"
-                 cy="68.752274"
-                 cx="94.084801"
-                 id="ellipse8890"
-                 style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.77952766;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-              <ellipse
-                 transform="translate(321.27978,-20.410715)"
-                 ry="14.967093"
-                 rx="17.038433"
-                 cy="89.598839"
-                 cx="-235.53128"
-                 id="ellipse8892"
-                 style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.77952766;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-              <ellipse
-                 ry="19.310225"
-                 rx="16.102989"
-                 cy="71.393105"
-                 cx="88.421188"
-                 id="ellipse8894"
-                 style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.77952766;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-            </g>
-          </g>
-          <g
-             id="g8840">
-            <g
-               id="g8791"
-               transform="translate(647.82943,-9.5725891)"
-               style="opacity:1">
-              <ellipse
-                 ry="43.603683"
-                 rx="94.955963"
-                 cy="86.948952"
-                 cx="-471.46347"
-                 id="path8749"
-                 style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.77952766;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-              <g
-                 style="opacity:1"
-                 id="g8704"
-                 transform="matrix(0.39124635,0,0,0.39124635,-504.87879,64.702247)">
-                <g
-                   id="g8485"
-                   style="opacity:1"
-                   transform="translate(579.28864,91.538536)">
-                  <ellipse
-                     ry="107.23515"
-                     rx="155.66002"
-                     cy="86.916267"
-                     cx="-494.34546"
-                     id="path8481"
-                     style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.55593443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-                  <ellipse
-                     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.41510725;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-                     id="ellipse8483"
-                     cx="-494.15247"
-                     cy="85.603592"
-                     rx="149.02174"
-                     ry="100.00879" />
-                </g>
-                <ellipse
-                   style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.77952766;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-                   id="path8489"
-                   cx="70.089607"
-                   cy="106.24013"
-                   rx="7.2456179"
-                   ry="9.177783" />
-                <ellipse
-                   ry="9.177783"
-                   rx="7.2456179"
-                   cy="105.75709"
-                   cx="101.7288"
-                   id="ellipse8491"
-                   style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.77952766;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-                <ellipse
-                   style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.77952766;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-                   id="path8493"
-                   cx="85.232826"
-                   cy="203.11064"
-                   rx="53.795967"
-                   ry="53.993904" />
-              </g>
-            </g>
-            <g
-               transform="matrix(-1,0,0,1,352.3838,2.4999198)"
-               id="g8830">
-              <g
-                 id="g8881">
-                <ellipse
-                   style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.77952766;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-                   id="ellipse8836"
-                   cx="94.084801"
-                   cy="68.752274"
-                   rx="32.406433"
-                   ry="22.712587" />
-                <ellipse
-                   style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.77952766;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-                   id="ellipse8834"
-                   cx="-235.53128"
-                   cy="89.598839"
-                   rx="17.038433"
-                   ry="14.967093"
-                   transform="translate(321.27978,-20.410715)" />
-                <ellipse
-                   style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.77952766;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-                   id="ellipse8838"
-                   cx="88.421188"
-                   cy="71.393105"
-                   rx="16.102989"
-                   ry="19.310225" />
-              </g>
-            </g>
-            <g
-               transform="translate(-236.84598,19.33214)"
-               id="g8949">
-              <g
-                 id="g8958">
-                <g
-                   transform="matrix(0.39124635,0,0,0.39124635,371.24827,-147.46559)"
-                   id="g8931"
-                   style="opacity:1">
-                  <g
-                     transform="matrix(0.53507953,0,0,0.53459184,216.67834,474.59437)"
-                     style="opacity:1"
-                     id="g8933">
-                    <ellipse
-                       style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.55593443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-                       id="ellipse8935"
-                       cx="-494.34546"
-                       cy="86.916267"
-                       rx="155.66002"
-                       ry="107.23515" />
-                  </g>
-                </g>
-                <g
-                   transform="translate(0.01048064,-9.8348782e-4)"
-                   style="opacity:1"
-                   id="g8927">
-                  <ellipse
-                     style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.77952766;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-                     id="path8923"
-                     cx="368.26971"
-                     cy="62.122162"
-                     rx="10.716969"
-                     ry="10.68356" />
-                  <ellipse
-                     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.77952766;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-                     id="path8925"
-                     cx="370.72446"
-                     cy="62.652016"
-                     rx="3.2664671"
-                     ry="3.2860374" />
-                </g>
-              </g>
-            </g>
-            <g
-               id="g8967"
-               transform="matrix(-1,0,0,1,589.6915,19.568376)">
-              <g
-                 id="g8969">
-                <g
-                   style="opacity:1"
-                   id="g8971"
-                   transform="matrix(0.39124635,0,0,0.39124635,371.24827,-147.46559)">
-                  <g
-                     id="g8973"
-                     style="opacity:1"
-                     transform="matrix(0.53507953,0,0,0.53459184,216.67834,474.59437)">
-                    <ellipse
-                       ry="107.23515"
-                       rx="155.66002"
-                       cy="86.916267"
-                       cx="-494.34546"
-                       id="ellipse8975"
-                       style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.55593443;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-                  </g>
-                </g>
-                <g
-                   id="g8979"
-                   style="opacity:1"
-                   transform="translate(-0.52405843,0.0658339)">
-                  <ellipse
-                     ry="10.68356"
-                     rx="10.716969"
-                     cy="62.122162"
-                     cx="368.26971"
-                     id="ellipse8981"
-                     style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.77952766;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-                  <ellipse
-                     ry="3.2860374"
-                     rx="3.2664671"
-                     cy="59.043877"
-                     cx="369.98947"
-                     id="ellipse8983"
-                     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.77952766;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <path
-           sodipodi:nodetypes="cssssscc"
-           inkscape:connector-curvature="0"
-           id="path8985"
-           d="m 199.99751,81.995416 c -0.31518,-0.546272 -4.14914,-6.045838 -6.76415,-9.615899 -1.85899,-2.537928 -5.16343,-6.251452 -7.61831,-8.75162 -1.35375,-1.378713 -2.76924,-2.276662 -2.3952,-2.900574 0,0 0.43492,1.72e-4 1.17382,-0.07074 1.4351,-0.137725 2.96609,-0.125479 2.96609,-0.125479 5.47016,6.121529 9.9132,12.629887 13.88825,18.554322 -0.13576,1.351342 -0.54492,2.362157 -1.2505,2.90999 z"
-           style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.27619353px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           inkscape:connector-curvature="0"
-           id="path8989"
-           d="m 196.5574,60.122377 3.43282,-0.127899 c 0,0 2.08984,5.505957 1.85361,6.261909 -0.23624,0.755952 -1.40931,1.447954 -1.40931,1.447954 z"
-           style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458335px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-        <path
-           sodipodi:nodetypes="csssscc"
-           inkscape:connector-curvature="0"
-           id="path8991"
-           d="m 199.27122,58.564169 c -2.80095,-5.681329 -6.43032,-13.840715 -11.86008,-18.742274 -0.38315,-0.34588 -1.16703,-0.163617 -1.53883,0.173126 -0.73101,0.6621 -0.75087,1.882509 -0.78762,2.857632 -0.0341,0.90496 0.0521,1.793156 0.7684,2.605876 4.88435,5.541871 7.39129,8.876402 10.12738,13.139055 z"
-           style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458335px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-        <path
-           sodipodi:nodetypes="casssscc"
-           inkscape:connector-curvature="0"
-           id="path8993"
-           d="m 186.03396,59.295554 c 0,0 -11.81357,-13.82818 -19.3004,-18.780693 -0.66233,-0.438124 -1.47747,-1.247385 -2.197,-0.921316 -0.75307,0.341265 -0.95385,1.370841 -0.92131,2.196985 0.0391,0.993209 0.11695,2.260635 0.75596,3.118305 1.22091,1.638708 3.16598,2.683999 4.6302,3.803386 5.82948,4.456587 13.40889,10.899276 13.13467,10.89044 z"
-           style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458335px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-      </g>
-      <g
-         id="g4925"
-         transform="matrix(0.92830058,-0.24873741,0.24873738,0.92830058,26.37755,90.762376)">
-        <g
-           id="flowRoot4626-4"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:'Source Code Pro';-inkscape-font-specification:'Source Code Pro';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           transform="matrix(0.32395506,0,0,0.32395508,-439.95643,-204.04921)">
+           style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.96135175;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="X"
+           transform="matrix(0.9180102,0,0,0.78032816,1.9677556,0.36020317)">
           <path
+             style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:22.67716408;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 895.96758,17.565617 c -4.51432,0.002 -7.40377,8.27e-4 -5.85625,-0.0031 l -474.25,0 -3.00195,0 c -0.25478,-0.01271 -0.49504,0.01017 -0.75,0 -1.01958,-0.04123 -1.98142,0 -3.00196,0 -1.27579,0 -2.47822,-0.06275 -3.75195,0 -1.00013,-0.03227 -2.00183,-0.03227 -3.00195,0 -5.4565,0.611688 -28.08495,5.779411 -40.52149,17.367188 -12.19948,11.365433 -15.37227,17.552642 -13.50586,32.492187 0.535,4.283194 2.10882,8.725204 3.75195,11.765625 0.82172,1.520255 1.03037,2.698601 1.5,3.361328 L 403.85547,194.5957 c 9.9444,22.57339 34.28873,31.41599 60.03125,31.37305 l 374.44726,0 c 27.51675,0.0466 50.22068,-9.66463 60.03125,-31.93359 L 950.14453,79.1875 c 2.31744,-5.152788 5.23306,-12.906133 3.75195,-21.849609 -1.4811,-8.943482 -7.59009,-17.849112 -15.75976,-24.650391 -8.59724,-7.160368 -20.24418,-12.644252 -30.76563,-14.564453 -4.35921,-0.795624 -8.21004,-0.558864 -11.40351,-0.55743 z"
+             transform="matrix(0.03662971,0,0,0.04906295,0.16337799,-0.66005961)"
+             id="q"
              inkscape:connector-curvature="0"
-             id="path3813-3"
-             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:192px;font-family:'Source Code Pro';-inkscape-font-specification:'Source Code Pro Bold'"
-             d="m 1850.8313,514.11027 23.424,0 0,-38.784 c 0,-14.016 -2.304,-44.544 -3.648,-57.984 l 0.576,0 9.024,33.408 9.792,30.144 13.824,0 9.6,-30.144 9.6,-33.408 0.576,0 c -1.152,13.44 -3.648,43.968 -3.648,57.984 l 0,38.784 23.808,0 0,-125.184 -29.568,0 -12.288,44.352 -4.224,17.28 -0.768,0 -4.224,-17.28 -12.288,-44.352 -29.568,0 0,125.184 z" />
+             sodipodi:nodetypes="sccccscccccccccccsccs" />
           <path
+             id="r"
+             d="m 15.980654,1.8522797 c -0.186932,0.028072 -0.385744,0.056129 -0.618134,0.3461553 -0.133765,0.1669203 -0.212827,0.4570536 -0.197802,0.618134 0.01502,0.1610805 0.06745,0.2275653 0.07418,0.2472538 l 1.70605,5.0687002 c 0.0038,0.011552 0.0204,0.01345 0.02473,0.024725 0.144719,0.3774207 0.550796,0.6188368 0.865388,0.6181342 l 12.337958,0 c 0.314595,7.026e-4 0.720665,-0.2407111 0.865388,-0.6181342 l 0.02473,0 c 0.0023,-0.00641 -0.0021,-0.01827 0,-0.024725 l 1.70605,-5.0687002 C 32.868724,2.7673573 32.893195,2.4802677 32.596101,2.1489842 32.277522,1.7935869 32.018901,1.8517916 31.879065,1.8522797 l -15.750059,0 c -0.0073,1.14e-4 -0.01735,1.14e-4 -0.02473,0 0.0055,-4.27e-5 -0.03025,-4.27e-5 -0.02473,0 a 0.7418641,0.7418641 0 0 0 -0.0989,0 z"
              inkscape:connector-curvature="0"
-             id="path3815-4"
-             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:192px;font-family:'Source Code Pro';-inkscape-font-specification:'Source Code Pro Bold'"
-             d="m 1968.2603,514.11027 28.224,0 0,-45.12 14.784,0 24,45.12 31.68,0 -28.224,-50.112 c 13.248,-5.952 22.272,-17.664 22.272,-36.096 0,-29.76 -21.888,-38.976 -48.384,-38.976 l -44.352,0 0,125.184 z m 28.224,-67.584 0,-35.136 13.824,0 c 14.976,0 22.848,4.224 22.848,16.512 0,12.288 -7.872,18.624 -22.848,18.624 l -13.824,0 z" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path3817-0"
-             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:192px;font-family:'Source Code Pro';-inkscape-font-specification:'Source Code Pro Bold'"
-             d="m 2083.3853,460.73427 88.32,0 0,-19.968 -88.32,0 0,19.968 z" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path3819-2"
-             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:192px;font-family:'Source Code Pro';-inkscape-font-specification:'Source Code Pro Bold'"
-             d="m 2199.4703,514.11027 28.224,0 0,-42.432 16.128,0 c 26.496,0 48.96,-13.056 48.96,-42.432 0,-30.336 -21.888,-40.32 -48.96,-40.32 l -44.352,0 0,125.184 z m 28.224,-64.896 0,-37.824 14.4,0 c 14.976,0 23.04,4.8 23.04,17.856 0,13.056 -7.488,19.968 -23.04,19.968 l -14.4,0 z" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path3821-6"
-             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:192px;font-family:'Source Code Pro';-inkscape-font-specification:'Source Code Pro Bold'"
-             d="m 2312.4833,514.11027 28.224,0 0,-52.224 34.176,0 0,52.224 28.224,0 0,-125.184 -28.224,0 0,48.192 -34.176,0 0,-48.192 -28.224,0 0,125.184 z" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path3823-7"
-             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:192px;font-family:'Source Code Pro';-inkscape-font-specification:'Source Code Pro Bold'"
-             d="m 2429.7203,514.11027 28.224,0 0,-42.432 16.128,0 c 26.496,0 48.96,-13.056 48.96,-42.432 0,-30.336 -21.888,-40.32 -48.96,-40.32 l -44.352,0 0,125.184 z m 28.224,-64.896 0,-37.824 14.4,0 c 14.976,0 23.04,4.8 23.04,17.856 0,13.056 -7.488,19.968 -23.04,19.968 l -14.4,0 z" />
+             style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.91633618;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         </g>
       </g>
     </g>


### PR DESCRIPTION
Per Discussion on munkireport slack channel:
Here is a new pinned tab SVG icon that fixes the issues of the original "Tombstone" icon. 