### PR TITLE
Sort machine groups by name

### DIFF
--- a/app/controllers/unit.php
+++ b/app/controllers/unit.php
@@ -90,6 +90,10 @@ class unit extends Controller
             $group['checked'] = in_array($group['groupid'], $groups);
         }
 
+        usort($out, function($a, $b) {
+            return strcmp($a['name'], $b['name']);
+        });
+        
         $obj = new View();
         $obj->view('json', array('msg' => $out));
     }


### PR DESCRIPTION
Having more than a few machine groups leads to an confusing filter view because the list was sorted by id and not by name. This pull request now sorts this list by group name.