### PR TITLE
Fix GPU vendors for 10.13

### DIFF
--- a/app/modules/gpu/gpu_model.php
+++ b/app/modules/gpu/gpu_model.php
@@ -127,8 +127,11 @@ class Gpu_model extends \Model {
 				$this->rs['vram'] = ($device['vram']." (Shared)");
             }
             
-            // Fix GMA model name
-            $this->rs['model'] = str_replace("GMA","Intel GMA",$this->rs['model']);
+            // Fix model names
+            $this->rs['model'] = str_replace(array("GMA","ATY,Radeon"),array("Intel GMA","ATI Radeon"),$this->rs['model']);
+            
+            // Fix vendors name
+            $this->rs['vendor'] = str_replace(array("sppci_vendor_amd","sppci_vendor_Nvidia"),array("AMD","NVIDIA"),$this->rs['model']);
             
 			// Save the GPU
 			$this->id = '';


### PR DESCRIPTION
10.13 changed the output of some GPU vendors, this adjusts for the change and fixes a problem with legacy ATI GPUs not having the correct name