### PR TITLE
Fix datatype in softwareupdate v3 migration

### DIFF
--- a/app/modules/softwareupdate/migrations/2017_12_19_200401_softwareupdate.php
+++ b/app/modules/softwareupdate/migrations/2017_12_19_200401_softwareupdate.php
@@ -12,7 +12,7 @@ class Softwareupdate extends Migration
             $table->increments('id');
             $table->string('serial_number')->unique();
 
-            $table->boolean('automaticcheckenabled')->nullable();
+            $table->integer('automaticcheckenabled')->nullable();
             $table->integer('automaticdownload')->nullable();
             $table->integer('configdatainstall')->nullable();
             $table->integer('criticalupdateinstall')->nullable();


### PR DESCRIPTION
Column "automaticcheckenabled" can be -1, changed datatype to be int