### PR TITLE
Smart stats report title fix

### DIFF
--- a/app/modules/smart_stats/views/smart_overall_health_test_widget.php
+++ b/app/modules/smart_stats/views/smart_overall_health_test_widget.php
@@ -5,7 +5,7 @@
 		<div class="panel-heading" data-container="body">
 
 			<h3 class="panel-title"><i class="fa fa-user-md"></i>
-			    <span data-i18n="smart_stats.smart_overall_health_test"></span>
+			    <span data-i18n="smart_stats.smart_stats.reporttitle"></span>
 			    <list-link data-url="/show/listing/smart_stats/smart_stats"></list-link>
 			</h3>
 


### PR DESCRIPTION
The report/widget title was missing due to misconfigured localization. Fixed it.