### PR TITLE
Security ssh detection update

### DIFF
--- a/app/controllers/clients.php
+++ b/app/controllers/clients.php
@@ -48,7 +48,7 @@ class clients extends Controller
 
             $sql = "SELECT m.*, r.console_user, r.long_username, r.remote_ip,
                         r.uptime, r.reg_timestamp, r.machine_group, r.timestamp,
-			s.gatekeeper, s.sip, s.ssh_users, s.ard_users, s.firmwarepw, s.firewall_state, s.skel_state,
+			s.gatekeeper, s.sip, s.ssh_groups, s.ssh_users, s.ard_users, s.firmwarepw, s.firewall_state, s.skel_state,
 			w.purchase_date, w.end_date, w.status, l.users, d.totalsize, d.freespace,
                         d.smartstatus, d.encrypted
                 FROM machine m

--- a/app/modules/security/locales/en.json
+++ b/app/modules/security/locales/en.json
@@ -12,6 +12,7 @@
     "sip_active": "SIP Active",
     "sip_disabled": "SIP Disabled",
     "sip_status": "SIP Status",
+    "ssh_groups": "SSH Groups",
     "ssh_users": "SSH Users",
     "skel": {
         "kext-loading": "KEXT Loading",

--- a/app/modules/security/migrations/2018_01_19_234938_security.php
+++ b/app/modules/security/migrations/2018_01_19_234938_security.php
@@ -1,0 +1,24 @@
+<?php
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Capsule\Manager as Capsule;
+
+
+class Security extends Migration
+{
+    private $tableName = 'security';
+	
+    public function up()
+    {
+		Schema::table($tableName, function($table) {
+			$table->string('ssh_groups')->after('sip');
+        }
+    }
+
+    public function down()
+    {
+		Schema::table($tableName, function($table) {
+			$table->dropColumn($columnName);
+        }
+    }
+}

--- a/app/modules/security/migrations/2018_01_19_234938_security.php
+++ b/app/modules/security/migrations/2018_01_19_234938_security.php
@@ -2,6 +2,7 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Support\Facades\Schema;
 
 
 class Security extends Migration

--- a/app/modules/security/migrations/2018_01_19_234938_security.php
+++ b/app/modules/security/migrations/2018_01_19_234938_security.php
@@ -1,25 +1,32 @@
 <?php
+
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Capsule\Manager as Capsule;
-use Illuminate\Support\Facades\Schema;
-
 
 class Security extends Migration
-{
+{    
     private $tableName = 'security';
-	
+
     public function up()
     {
-		Schema::table($tableName, function($table) {
+    
+		$capsule = new Capsule();
+
+        $capsule::schema()->table($this->tableName, function (Blueprint $table) {
 			$table->string('ssh_groups')->after('sip');
+						
         });
     }
 
     public function down()
     {
-		Schema::table($tableName, function($table) {
-			$table->dropColumn($columnName);
+
+		$capsule = new Capsule();
+
+        $capsule::schema()->table($this->tableName, function (Blueprint $table) {
+			$table->dropColumn('ssh_groups');
         });
     }
 }

--- a/app/modules/security/migrations/2018_01_19_234938_security.php
+++ b/app/modules/security/migrations/2018_01_19_234938_security.php
@@ -12,13 +12,13 @@ class Security extends Migration
     {
 		Schema::table($tableName, function($table) {
 			$table->string('ssh_groups')->after('sip');
-        }
-    });
+        });
+    }
 
     public function down()
     {
 		Schema::table($tableName, function($table) {
 			$table->dropColumn($columnName);
-        }
-    });
+        });
+    }
 }

--- a/app/modules/security/migrations/2018_01_19_234938_security.php
+++ b/app/modules/security/migrations/2018_01_19_234938_security.php
@@ -13,12 +13,12 @@ class Security extends Migration
 		Schema::table($tableName, function($table) {
 			$table->string('ssh_groups')->after('sip');
         }
-    }
+    });
 
     public function down()
     {
 		Schema::table($tableName, function($table) {
 			$table->dropColumn($columnName);
         }
-    }
+    });
 }

--- a/app/modules/security/scripts/security.py
+++ b/app/modules/security/scripts/security.py
@@ -254,8 +254,7 @@ def main():
 
     # Write results of checks to cache file
     output_plist = os.path.join(cachedir, 'security.plist')
-    #plistlib.writePlist(result, output_plist)
-    print result
+    plistlib.writePlist(result, output_plist)
     
 if __name__ == "__main__":
     main()

--- a/app/modules/security/scripts/security.py
+++ b/app/modules/security/scripts/security.py
@@ -102,8 +102,9 @@ def ssh_group_access_check():
         out, err = sp.communicate()
 
         if "com.apple.access_ssh-disabled" in out:
-            # if this group exists, all users are permitted to access SSH
-            return "All users permitted"
+            # if this group exists, all users are permitted to access SSH. 
+            # Nothing group specific
+            pass
 
         elif "com.apple.access_ssh" in out:
             # Get a list of UUIDs of Nested Groups
@@ -127,9 +128,10 @@ def ssh_group_access_check():
             return ' '.join(item for item in group_list)
 
         else:
-            # if neither SSH group exists but SSH is enabled, it was turned on with
+            # If neither SSH group exists but SSH is enabled, it was turned on with
             # systemsetup and all users are enabled.
-            return "All users permitted"
+            # Nothing group specific            
+            pass
 
 def ard_access_check():
     """Check for local users who have ARD permissions
@@ -252,7 +254,8 @@ def main():
 
     # Write results of checks to cache file
     output_plist = os.path.join(cachedir, 'security.plist')
-    plistlib.writePlist(result, output_plist)
-
+    #plistlib.writePlist(result, output_plist)
+    print result
+    
 if __name__ == "__main__":
     main()

--- a/app/modules/security/scripts/security.py
+++ b/app/modules/security/scripts/security.py
@@ -71,7 +71,7 @@ def ssh_user_access_check():
             user_out, user_err = user_sp.communicate()
             user_list = user_out.split()
                 
-            return ' '.join(item for item in user_list[1:])
+            return ', '.join(item for item in user_list[1:])
 
         else:
             # if neither SSH group exists but SSH is enabled, it was turned on with
@@ -113,19 +113,13 @@ def ssh_group_access_check():
             group_list_uuid = group_out.split()
             
             # Translate group UUIDs to gids
-            group_ids = []
+            group_list = []
             for group_uuid in group_list_uuid[1:]:
                 group_id_sp = subprocess.Popen(['dsmemberutil', 'getid', '-x', group_uuid], stdout=subprocess.PIPE)
                 group_id_out, group_id_err = group_id_sp.communicate()
-                group_list_id = group_id_out.split()
-                group_ids.append(group_list_id[1])
+                group_list.append(grp.getgrgid(group_id_out.split()[1]).gr_name)
                 
-            # Get the name of the gids
-            group_list = []
-            for group_id in group_ids:
-                group_list.append(grp.getgrgid(group_id).gr_name)
-                
-            return ' '.join(item for item in group_list)
+            return ', '.join(item for item in group_list)
 
         else:
             # If neither SSH group exists but SSH is enabled, it was turned on with

--- a/app/modules/security/scripts/security.py
+++ b/app/modules/security/scripts/security.py
@@ -71,7 +71,7 @@ def ssh_user_access_check():
             user_out, user_err = user_sp.communicate()
             user_list = user_out.split()
                 
-            return user_list[1:]
+            return ' '.join(item for item in user_list[1:])
 
         else:
             # if neither SSH group exists but SSH is enabled, it was turned on with
@@ -124,7 +124,7 @@ def ssh_group_access_check():
             for group_id in group_ids:
                 group_list.append(grp.getgrgid(group_id).gr_name)
                 
-            return group_list
+            return ' '.join(item for item in group_list)
 
         else:
             # if neither SSH group exists but SSH is enabled, it was turned on with

--- a/app/modules/security/security_model.php
+++ b/app/modules/security/security_model.php
@@ -11,6 +11,7 @@ class Security_model extends \Model
         $this->rs['serial_number'] = $serial; //$this->rt['serial_number'] = 'VARCHAR(255) UNIQUE';
         $this->rs['gatekeeper'] = '';
     	$this->rs['sip'] = '';
+    	$this->rs['ssh_groups'] = '';
     	$this->rs['ssh_users'] = '';
     	$this->rs['ard_users'] = '';
         $this->rs['firmwarepw'] = '';
@@ -21,6 +22,7 @@ class Security_model extends \Model
         $this->idx[] = array('serial_number');
         $this->idx[] = array('gatekeeper');
         $this->idx[] = array('sip');
+        $this->idx[] = array('ssh_groups');
         $this->idx[] = array('ssh_users');
         $this->idx[] = array('ard_users');
         $this->idx[] = array('firmwarepw');
@@ -28,7 +30,7 @@ class Security_model extends \Model
         $this->idx[] = array('skel_state');
 
         // Schema version, increment when creating a db migration
-        $this->schema_version = 6;
+        $this->schema_version = 7;
         
         // Create table if it does not exist
        //$this->create_table();
@@ -61,7 +63,7 @@ class Security_model extends \Model
 
     		$plist = $parser->toArray();
 
-    		foreach (array('sip', 'gatekeeper', 'ssh_users', 'ard_users', 'firmwarepw', 'firewall_state', 'skel_state') as $item) {
+    		foreach (array('sip', 'gatekeeper', 'ssh_groups', 'ssh_users', 'ard_users', 'firmwarepw', 'firewall_state', 'skel_state') as $item) {
     			if (isset($plist[$item])) {
     				$this->$item = $plist[$item];
     			} else {

--- a/app/modules/security/views/security_listing.php
+++ b/app/modules/security/views/security_listing.php
@@ -31,6 +31,7 @@ new Security_model;
 		        <th data-i18n="security.firmwarepw" data-colname='security.firmwarepw'></th>
                 <th data-i18n="security.firewall_state" data-colname='security.firewall_state'></th>
                 <th data-i18n="security.skel.kext-loading" data-colname='security.skel_state'></th>
+                <th data-i18n="security.ssh_groups" data-colname='security.ssh_groups'></th>
 		        <th data-i18n="security.ssh_users" data-colname='security.ssh_users'></th>
 		        <th data-i18n="security.ard_users" data-colname='security.ard_users'></th>
 		      </tr>

--- a/app/views/client/summary_tab.php
+++ b/app/views/client/summary_tab.php
@@ -187,6 +187,9 @@
 					<th data-i18n="security.sip"></th><td class="mr-sip"></td>
 				</tr>
 				<tr>
+					<th data-i18n="security.ssh_groups"></th><td class="mr-ssh_groups"></td>
+				</tr>
+				<tr>
 					<th data-i18n="security.ssh_users"></th><td class="mr-ssh_users"></td>
 				</tr>
 				<tr>


### PR DESCRIPTION
The current SSH information in the Client Details and Security Listing doesn't include group or directory based users.

The changes I incorporated gather user and group information from the com.apple.ssh_access group.

Users that are explicitly added in the Remote Login Preference pane are listed in the GroupMemberships key.  

Groups are a little trickier as they are only stored as UUIDs.  Using a couple loops those UUIDs can be converted to group names.  

Since groups are now supported I thought it didn't make much sense to use the previous method of evaluating each local user against the com.apple.ssh_access list to check if they are members.  That method won't catch directory based groups would not list all of it's members as SSH Users.

Since this is my first go at a v3 migration I'd appreciate a keen eye on how the migration is performed.  In testing the current code appears to work fine.