### PR TITLE
Create widget for os build breakdown and add it to the client report

### DIFF
--- a/app/modules/machine/machine_controller.php
+++ b/app/modules/machine/machine_controller.php
@@ -189,4 +189,29 @@ class Machine_controller extends Module_controller
         $obj = new View();
         $obj->view('json', array('msg' => $out));
     }
+    /**
+     * Return json array with os build breakdown
+     *
+     * @author AkB
+     **/
+    public function osbuild()
+    {
+        $out = array();
+        $machine = new Machine_model();
+        $sql = "SELECT count(1) as count, buildversion
+        FROM machine
+        LEFT JOIN reportdata USING (serial_number)
+        ".get_machine_group_filter()."
+        GROUP BY buildversion
+        ORDER BY buildversion DESC";
+
+        foreach ($machine->query($sql) as $obj) {
+            $obj->buildversion = $obj->buildversion ? $obj->buildversion : '0';
+            $out[] = array('label' => $obj->buildversion, 'count' => intval($obj->count));
+        }
+
+
+        $obj = new View();
+        $obj->view('json', array('msg' => $out));
+    }
 } // END class Machine_controller

--- a/app/modules/machine/provides.php
+++ b/app/modules/machine/provides.php
@@ -13,6 +13,7 @@ return array(
       'memory' => array('view' => 'memory_widget'),
       'new_clients' => array('view' => 'new_clients_widget'),
       'os' => array('view' => 'os_widget'),
+      'osbuild' => array('view' => 'osbuild_widget'),
     ),
     'reports' => array(
         'hardware' => array('view' => 'hardware', 'i18n' => 'machine.hardware_report'),

--- a/app/modules/machine/views/osbuild_widget.php
+++ b/app/modules/machine/views/osbuild_widget.php
@@ -1,0 +1,43 @@
+<div class="col-md-6">
+
+	<div class="panel panel-default" id="osbuild-widget">
+
+		<div class="panel-heading">
+
+			<h3 class="panel-title"><i class="fa fa-apple"></i>
+			    <span data-i18n="machine.osbuild.title"></span>
+			    <list-link data-url="/show/listing/reportdata/clients"></list-link>
+			</h3>
+
+		</div>
+
+		<div class="panel-body">
+
+			<svg style="width:100%"></svg>
+
+		</div>
+
+	</div><!-- /panel -->
+
+</div><!-- /col-lg-4 -->
+
+<script>
+$(document).on('appReady', function(e, lang) {
+
+	var conf = {
+		url: appUrl + '/module/machine/osbuild', // Url for json
+		widget: 'osbuild-widget', // Widget id
+		elementClickCallback: function(e){
+			var label = e.data.label;
+			window.location.href = appUrl + '/show/listing/reportdata/clients#' + label;
+		},
+		labelModifier: function(label){
+			return label
+		}
+	};
+
+	mr.addGraph(conf);
+
+});
+
+</script>

--- a/app/modules/reportdata/views/clients.php
+++ b/app/modules/reportdata/views/clients.php
@@ -24,6 +24,9 @@
 
     <?php $widget->view($this, 'os'); ?>
 
+    <?php $widget->view($this, 'osbuild'); ?>
+
+
   </div> <!-- /row -->
 
 </div>  <!-- /container -->

--- a/public/assets/locales/en.json
+++ b/public/assets/locales/en.json
@@ -220,6 +220,9 @@
         "os": {
             "title": "OS Breakdown"
         },
+	"osbuild": {
+            "title": "OS Build Breakdown"
+	},
         "registered": {
             "title": "Client Registration Over Time"
         },


### PR DESCRIPTION
Create an os build widget (unabashedly based on the existing os build widget) and add it to the Clients Report by default. I served this using the included Dockerfile and client [os builds were available](https://i.imgur.com/BzZpCQ5.png) on the widget as I'd expect.

Any feedback appreciated!