### PR TITLE
Adjust database log view to use theme for readability.

### DIFF
--- a/public/assets/css/system/database.css
+++ b/public/assets/css/system/database.css
@@ -1,5 +1,4 @@
 .table-console {
-    background: beige;
     color: darkgrey;
     font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
     font-size: 1.4rem;


### PR DESCRIPTION
The background color on the database log view is hard coded and makes it hard to read the content on some themes due to font/background contrast.  Removing the background color defaults back to the theme's CSS. I didn't see any issues in cycling thru the different themes.