### PR TITLE
Make tag report name title case

### DIFF
--- a/app/modules/tag/locales/en.json
+++ b/app/modules/tag/locales/en.json
@@ -1,6 +1,6 @@
 {
     "listing": {
-      "title": "Tag report"
+      "title": "Tag Report"
     },
     "name": "Tag Name",
     "widget_title": "Tags",


### PR DESCRIPTION
To make the listing's titles uniform