### PR TITLE
Fix security module migration

### DIFF
--- a/app/modules/security/migrations/2017_02_09_234938_security.php
+++ b/app/modules/security/migrations/2017_02_09_234938_security.php
@@ -27,13 +27,13 @@ class Security extends Migration
         $capsule::schema()->create($this->tableName, function (Blueprint $table) {
             $table->increments('id');
             $table->string('serial_number');
-            $table->string('gatekeeper');
-            $table->string('sip');
-            $table->string('ssh_users');
-            $table->string('ard_users');
-            $table->string('firmwarepw');
-            $table->string('firewall_state');
-            $table->string('skel_state');
+            $table->string('gatekeeper')->nullable();
+            $table->string('sip')->nullable();
+            $table->string('ssh_users')->nullable();
+            $table->string('ard_users')->nullable();
+            $table->string('firmwarepw')->nullable();
+            $table->string('firewall_state')->nullable();
+            $table->string('skel_state')->nullable();
         });
 
         if ($migrateData) {


### PR DESCRIPTION
The migration doesn't allow null values and failed migration if values are blank.