### PR TITLE
Add option to use current username for ssh link

### DIFF
--- a/config_default.php
+++ b/config_default.php
@@ -230,6 +230,10 @@
 	| want the links, set either to an empty string, eg:
 	| $conf['vnc_link'] = "";
 	|
+	| If you want to authenticate with SSH using the currently logged in user 
+	| replace the username in the SSH config with %u: 
+	| $conf['ssh_link'] = "ssh://%u@%s";
+	|
 	*/
 	$conf['vnc_link'] = "vnc://%s:5900";
 	$conf['ssh_link'] = "ssh://adminuser@%s";

--- a/public/assets/js/clients/client_detail.js
+++ b/public/assets/js/clients/client_detail.js
@@ -173,11 +173,12 @@ $(document).on('appReady', function(e, lang) {
 		$( "time" ).each(function( index ) {
 				$(this).tooltip().css('cursor', 'pointer');
 		});
-
+		
+		var username=$('nav i.fa-user')[0].nextSibling.nodeValue.trim();
 		// Remote control links
 		$.getJSON( appUrl + '/clients/get_links', function( links ) {
 			$.each(links, function(prop, val){
-				$('#client_links').append('<li><a href="'+(val.replace(/%s/, machineData.remote_ip))+'">'+i18n.t('remote_control')+' ('+prop+')</a></li>');
+				$('#client_links').append('<li><a href="'+(val.replace(/%s/, machineData.remote_ip).replace(/%u/, username))+'">'+i18n.t('remote_control')+' ('+prop+')</a></li>');
 			});
 		});
 


### PR DESCRIPTION
Using the method to get the current username from https://github.com/munkireport/munkireport-php/issues/877 this change allows an admin to use a custom ssh_link config to replace the username with the current user logged into Munkireport.  This is beneficial when directory based logins are used.

Adding `$conf['ssh_link'] = "ssh://%u@%s";` to config.php will result in the username being substituted in.  If the custom config is not in config.php the %u substitution does not take place.

-Eric