### PR TITLE
Add disable_sso_sls_verify config option

### DIFF
--- a/app/lib/munkireport/AuthSaml.php
+++ b/app/lib/munkireport/AuthSaml.php
@@ -184,6 +184,12 @@ class AuthSaml extends AbstractAuth
                 echo '<p>' . implode(', ', $errors) . '</p>';
             }
         } catch (OneLogin_Saml2_Error $e) {
+            if(isset($this->config['disable_sso_sls_verify']) && $this->config['disable_sso_sls_verify'] === true){
+                session_destroy();
+                $obj = new View();
+                $obj->view('auth/logout', ['loginurl' => url()]);
+                return;
+            }
             echo 'An error occurred during logout';
             print_r($e->getMessage());
         }

--- a/app/lib/munkireport/AuthSaml.php
+++ b/app/lib/munkireport/AuthSaml.php
@@ -184,7 +184,7 @@ class AuthSaml extends AbstractAuth
                 echo '<p>' . implode(', ', $errors) . '</p>';
             }
         } catch (OneLogin_Saml2_Error $e) {
-            if(isset($this->config['disable_sso_sls_verify']) && $this->config['disable_sso_sls_verify'] === true){
+            if(isset($this->config['disable_sso_sls_verify']) && $this->config['disable_sso_sls_verify'] === true && strpos($e->getMessage(),'Only supported HTTP_REDIRECT Binding') !== false ){
                 session_destroy();
                 $obj = new View();
                 $obj->view('auth/logout', ['loginurl' => url()]);


### PR DESCRIPTION
Allowing for a `disable_sso_sls_verify` configuration option.  This was brought about when trying to integrate with Okta for single logout.  Okta insists on sending a HTTP_POST when confirming an SLO request which the underlying Onelogin Saml-PHP framework is not currently compatible with. The Sign out process doe in fact complete but our app is not able to verify the HTTP_POST response.

I am proposing that by setting this `disable_sso_sls_verify` to true, if we encounter an error on SLO processing, we assume the request succeeded, kill the current user session and redirect to a logout page.

I can update the wiki if accepted.