### PR TITLE
Added local network ip option for vnc and ssh links

### DIFF
--- a/app/controllers/clients.php
+++ b/app/controllers/clients.php
@@ -3,7 +3,7 @@
 namespace munkireport\controller;
 
 use \Controller, \View;
-use \Machine_model, \Reportdata_model, \Disk_report_model, \Warranty_model, \Localadmin_model, \Security_model;
+use \Machine_model, \Reportdata_model, \Disk_report_model, \Warranty_model, \Localadmin_model, \Security_model, \Network_model;
 
 
 
@@ -45,18 +45,20 @@ class clients extends Controller
             new Warranty_model;
             new Localadmin_model;
             new Security_model;
+	    new Network_model;
 
             $sql = "SELECT m.*, r.console_user, r.long_username, r.remote_ip,
                         r.uptime, r.reg_timestamp, r.machine_group, r.timestamp,
 			s.gatekeeper, s.sip, s.ssh_groups, s.ssh_users, s.ard_users, s.firmwarepw, s.firewall_state, s.skel_state,
 			w.purchase_date, w.end_date, w.status, l.users, d.totalsize, d.freespace,
-                        d.smartstatus, d.encrypted
+                        d.smartstatus, d.encrypted, n.ipv4ip, n.ipv6ip
                 FROM machine m
                 LEFT JOIN reportdata r ON (m.serial_number = r.serial_number)
                 LEFT JOIN security s ON (m.serial_number = s.serial_number)
                 LEFT JOIN warranty w ON (m.serial_number = w.serial_number)
                 LEFT JOIN localadmin l ON (m.serial_number = l.serial_number)
                 LEFT JOIN diskreport d ON (m.serial_number = d.serial_number AND d.mountpoint = '/')
+		LEFT JOIN network n ON (m.serial_number = n.serial_number)
                 WHERE m.serial_number = ?
                 ";
 

--- a/config_default.php
+++ b/config_default.php
@@ -226,6 +226,13 @@
 	| VNC and SSH links, optional links in the client detail view
 	|===============================================
 	|
+	| Substitutions key:
+	|   %s = remote IP
+	|   %remote_ip = remote IP (same as above but easier to read in the config)
+        |   %u = logged in username
+        |   %network_ip_v4 = local network ipv4 address
+        |   %network_ip_v6 = local network ipv6 address
+	|
 	| If you want to have link that opens a screensharing or SSH
 	| connection to a client, enable these settings. If you don't
 	| want the links, set either to an empty string, eg:
@@ -234,7 +241,6 @@
 	| If you want to authenticate with SSH using the currently logged in user 
 	| replace the username in the SSH config with %u: 
 	| $conf['ssh_link'] = "ssh://%u@%s";
-	|
 	*/
 	$conf['vnc_link'] = "vnc://%s:5900";
 	$conf['ssh_link'] = "ssh://adminuser@%s";

--- a/public/assets/js/clients/client_detail.js
+++ b/public/assets/js/clients/client_detail.js
@@ -178,7 +178,7 @@ $(document).on('appReady', function(e, lang) {
 		// Remote control links
 		$.getJSON( appUrl + '/clients/get_links', function( links ) {
 			$.each(links, function(prop, val){
-				$('#client_links').append('<li><a href="'+(val.replace(/%s/, machineData.remote_ip).replace(/%u/, username))+'">'+i18n.t('remote_control')+' ('+prop+')</a></li>');
+				$('#client_links').append('<li><a href="'+(val.replace(/%s/, machineData.remote_ip).replace(/%remote_ip/, machineData.remote_ip).replace(/%u/, username).replace(/%network_ip_v4/, machineData.ipv4ip).replace(/%network_ip_v6/, machineData.ipv6ip))+'">'+i18n.t('remote_control')+' ('+prop+')</a></li>');
 			});
 		});
 


### PR DESCRIPTION
Attempt to address issue #878

This gives the admin the option to use the internally detected network IPs from the network table for the SSH and VNC remote control links.

If a machine has multiple internal IP addresses only one is returned.  As long as it has one internal IP on wired or wireless it should be reachable. 

-Eric