### PR TITLE
Add UID to reportdata, user_sessions module, localadmin module, and client summary

### DIFF
--- a/app/controllers/clients.php
+++ b/app/controllers/clients.php
@@ -47,7 +47,7 @@ class clients extends Controller
             new Security_model;
 
             $sql = "SELECT m.*, r.console_user, r.long_username, r.remote_ip,
-                        r.uptime, r.reg_timestamp, r.machine_group, r.timestamp,
+                        r.uid, r.uptime, r.reg_timestamp, r.machine_group, r.timestamp,
 			s.gatekeeper, s.sip, s.ssh_groups, s.ssh_users, s.ard_users, s.firmwarepw, s.firewall_state, s.skel_state,
 			w.purchase_date, w.end_date, w.status, l.users, d.totalsize, d.freespace,
                         d.smartstatus, d.encrypted

--- a/app/modules/localadmin/scripts/localadmin
+++ b/app/modules/localadmin/scripts/localadmin
@@ -16,7 +16,8 @@ admin_users=''
 for user in $(dscl . -list /Users | grep -v "^_\|^root$") ; do
 	ismember=$(dsmemberutil checkmembership -U $user -G admin)
 	case $ismember in
-		*'user is a member of the group'*) admin_users+=( $user );;
+		*'user is a member of the group'*)  uid=$(/usr/bin/id -u $user)
+											admin_users+=( $user \($uid\) );;
 	esac
 done
 

--- a/app/modules/reportdata/migrations/2018_04_12_064804_reportdata_add_uid.php
+++ b/app/modules/reportdata/migrations/2018_04_12_064804_reportdata_add_uid.php
@@ -1,0 +1,28 @@
+<?php
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Capsule\Manager as Capsule;
+
+class ReportdataAddUid extends Migration
+{
+    private $tableName = 'reportdata';
+
+    public function up()
+    {
+        $capsule = new Capsule();
+        $capsule::schema()->table($this->tableName, function (Blueprint $table) {
+            $table->integer('uid')->nullable();
+            
+            $table->index('uid');
+        });
+    }
+    
+    public function down()
+    {
+        $capsule = new Capsule();
+        $capsule::schema()->table($this->tableName, function (Blueprint $table) {
+
+            $table->dropColumn('uid');
+        });
+    }
+}

--- a/app/modules/reportdata/reportdata_model.php
+++ b/app/modules/reportdata/reportdata_model.php
@@ -12,6 +12,7 @@ class Reportdata_model extends \Model
         $this->rs['serial_number'] = '';
         $this->rs['console_user'] = '';
         $this->rs['long_username'] = '';
+        $this->rs['uid'] = 0;
         $this->rs['remote_ip'] = '';
         $this->rs['uptime'] = 0;
         $this->rs['reg_timestamp'] = time(); // Registration date
@@ -149,6 +150,11 @@ class Reportdata_model extends \Model
         // If long_username is empty, retain previous entry
         if (array_key_exists('long_username', $mylist) && empty($mylist['long_username'])) {
             unset($mylist['long_username']);
+        }
+
+        // If uid is empty, retain previous entry
+        if (array_key_exists('uid', $mylist) && empty($mylist['uid'])) {
+            unset($mylist['uid']);
         }
 
         $this->merge($mylist)->register()->save();

--- a/app/modules/reportdata/reportdata_processor.php
+++ b/app/modules/reportdata/reportdata_processor.php
@@ -36,6 +36,11 @@ class Reportdata_processor
             unset($mylist['long_username']);
         }
 
+        // If uid is empty, retain previous entry
+        if (array_key_exists('uid', $mylist) && empty($mylist['uid'])) {
+            unset($mylist['uid']);
+        }
+
         $model = Reportdata_model::updateOrCreate(
             ['serial_number' => $this->serial_number],
             $mylist

--- a/app/modules/user_sessions/locales/en.json
+++ b/app/modules/user_sessions/locales/en.json
@@ -8,5 +8,6 @@
     "ipaddress": "Remote SSH IP Address",
     "login": "Login",
     "logout": "Logout",
+    "last_user_uid": "Last User UID",
     "uid": "UID"
 }

--- a/app/modules/user_sessions/locales/en.json
+++ b/app/modules/user_sessions/locales/en.json
@@ -7,5 +7,6 @@
     "sshlogin": "SSH Login",
     "ipaddress": "Remote SSH IP Address",
     "login": "Login",
-    "logout": "Logout"
+    "logout": "Logout",
+    "uid": "UID"
 }

--- a/app/modules/user_sessions/locales/fr.json
+++ b/app/modules/user_sessions/locales/fr.json
@@ -7,5 +7,6 @@
     "sshlogin": "Connexion SSH",
     "ipaddress": "Remote SSH IP Address",
     "login": "Connexion",
-    "logout": "Déconnexion"
+    "logout": "Déconnexion",
+    "uid": "UID"
 }

--- a/app/modules/user_sessions/locales/fr.json
+++ b/app/modules/user_sessions/locales/fr.json
@@ -8,5 +8,6 @@
     "ipaddress": "Remote SSH IP Address",
     "login": "Connexion",
     "logout": "Déconnexion",
+    "last_user_uid": "Last User UID",
     "uid": "UID"
 }

--- a/app/modules/user_sessions/migrations/2018_04_12_055955_user_sessions_add_user_uid.php
+++ b/app/modules/user_sessions/migrations/2018_04_12_055955_user_sessions_add_user_uid.php
@@ -1,0 +1,28 @@
+<?php
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Capsule\Manager as Capsule;
+
+class UserSessionsAddUserUid extends Migration
+{
+    private $tableName = 'user_sessions';
+
+    public function up()
+    {
+        $capsule = new Capsule();
+        $capsule::schema()->table($this->tableName, function (Blueprint $table) {
+             $table->integer('uid')->nullable();
+            
+             $table->index('uid');
+        });
+    }
+    
+    public function down()
+    {
+        $capsule = new Capsule();
+        $capsule::schema()->table($this->tableName, function (Blueprint $table) {
+
+            $table->dropColumn('uid');;
+        });
+    }
+}

--- a/app/modules/user_sessions/scripts/user_sessions.py
+++ b/app/modules/user_sessions/scripts/user_sessions.py
@@ -55,8 +55,8 @@ class utmpx(Structure):
                ]
 
 
-def get_uid(uid):
-    cmd = ['/usr/bin/id', '-u', uid]
+def get_uid(username):
+    cmd = ['/usr/bin/id', '-u', username]
     proc = subprocess.Popen(cmd, shell=False, bufsize=-1,
                             stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/app/modules/user_sessions/scripts/user_sessions.py
+++ b/app/modules/user_sessions/scripts/user_sessions.py
@@ -25,6 +25,7 @@ import plistlib
 import os
 import sys
 import time
+import subprocess
 
 # constants
 c = CDLL(find_library("System"))
@@ -53,6 +54,15 @@ class utmpx(Structure):
                 ("ut_pad",  c_uint32*16),
                ]
 
+
+def get_uid(uid):
+    cmd = ['/usr/bin/id', '-u', uid]
+    proc = subprocess.Popen(cmd, shell=False, bufsize=-1,
+                            stdin=subprocess.PIPE,
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    (output, unused_error) = proc.communicate()
+    output = output.strip()
+    return output
 
 def fast_last(session='gui_ssh'):
     """This method will replicate the functionallity of the /usr/bin/last
@@ -99,6 +109,9 @@ def fast_last(session='gui_ssh'):
             event = {'event': event_label,
                      'user': e.ut_user,
                      'time': e.ut_tv.tv_sec}
+                     
+            if e.ut_user != "":
+            	event['uid'] = get_uid(e.ut_user)
             if e.ut_host != "":
                 event['remote_ssh'] = e.ut_host
 

--- a/app/modules/user_sessions/user_sessions_model.php
+++ b/app/modules/user_sessions/user_sessions_model.php
@@ -12,6 +12,7 @@ class User_sessions_model extends \Model {
 		$this->rs['event'] = '';
 		$this->rs['time'] = 0;
 		$this->rs['user'] = '';
+		$this->rs['uid'] = 0;
 		$this->rs['remote_ssh'] = '';
 
 		// Schema version, increment when creating a db migration
@@ -21,6 +22,7 @@ class User_sessions_model extends \Model {
 		$this->idx[] = array('event');
 		$this->idx[] = array('time');
 		$this->idx[] = array('user');
+		$this->idx[] = array('uid');
 		$this->idx[] = array('remote_ssh');
 
 		// Create table if it does not exist
@@ -54,6 +56,7 @@ class User_sessions_model extends \Model {
 			'event' => '',
 			'time' => 0,
 			'user' => '',
+			'uid' => 0,
 			'remote_ssh' => ''
 		);
 

--- a/app/modules/user_sessions/user_sessions_model.php
+++ b/app/modules/user_sessions/user_sessions_model.php
@@ -12,7 +12,7 @@ class User_sessions_model extends \Model {
 		$this->rs['event'] = '';
 		$this->rs['time'] = 0;
 		$this->rs['user'] = '';
-		$this->rs['uid'] = 0;
+		$this->rs['uid'] = NULL;
 		$this->rs['remote_ssh'] = '';
 
 		// Schema version, increment when creating a db migration
@@ -56,7 +56,7 @@ class User_sessions_model extends \Model {
 			'event' => '',
 			'time' => 0,
 			'user' => '',
-			'uid' => 0,
+			'uid' => NULL,
 			'remote_ssh' => ''
 		);
 

--- a/app/modules/user_sessions/views/user_sessions_listing.php
+++ b/app/modules/user_sessions/views/user_sessions_listing.php
@@ -19,6 +19,7 @@ new User_sessions_model;
 		      	<th data-i18n="serial" data-colname='reportdata.serial_number'></th>
 		      	<th data-i18n="event" data-colname='user_sessions.event'></th>
 		      	<th data-i18n="username" data-colname='user_sessions.user'></th>
+		      	<th data-i18n="user_sessions.uid" data-colname='user_sessions.uid'></th>		      	
 		      	<th data-i18n="user_sessions.ipaddress" data-colname='user_sessions.remote_ssh'></th>
 		      	<th data-i18n="user_sessions.time" data-colname='user_sessions.time'></th>
 		      </tr>
@@ -97,9 +98,9 @@ new User_sessions_model;
 	        	$('td:eq(2)', nRow).html(eventlocal)
 
 	        	// Format date
-	        	var event = parseInt($('td:eq(5)', nRow).html());
+	        	var event = parseInt($('td:eq(6)', nRow).html());
 	        	var date = new Date(event * 1000);
-	        	$('td:eq(5)', nRow).html('<span title="' + moment(date).format('llll') + '">'+moment(date).fromNow()+'</span>');
+	        	$('td:eq(6)', nRow).html('<span title="' + moment(date).format('llll') + '">'+moment(date).fromNow()+'</span>');
 
 		    }
 	    } );

--- a/app/modules/user_sessions/views/user_sessions_tab.php
+++ b/app/modules/user_sessions/views/user_sessions_tab.php
@@ -4,6 +4,7 @@
 		<tr>
             <th data-i18n="event"></th>
             <th data-i18n="username"></th>
+            <th data-i18n="user_sessions.uid"></th>
             <th data-i18n="user_sessions.ipaddress"></th>
             <th data-i18n="user_sessions.time"></th>
 		</tr>
@@ -14,6 +15,7 @@
         <tr>
           <td><?php echo str_replace(array('sshlogin','login','logout','shutdown','reboot'), array('SSH Login','Login','Logout','Shutdown','Reboot'), $item->event); ?></td>
           <td><?php echo $item->user; ?></td>
+          <td><?php echo $item->uid; ?></td>
           <td><?php echo $item->remote_ssh; ?></td>
           <td><?php echo date("Y-m-d H:i:s", $item->time); ?></td>
         </tr>
@@ -26,7 +28,7 @@
         // Initialize datatables
             $('.user_sessions').dataTable({
                 "bServerSide": false,
-                "aaSorting": [[3,'asc']]
+                "aaSorting": [[4,'asc']]
             });
   });
 </script>

--- a/app/views/client/summary_tab.php
+++ b/app/views/client/summary_tab.php
@@ -143,6 +143,9 @@
 				(<span class="mr-console_user"></span>)</td>
 				</tr>
 				<tr>
+					<th data-i18n="user_sessions.uid"></th><td><span class="mr-uid"></span></td>
+				</tr>
+				<tr>
 					<th data-i18n="user.local_admins"></th><td class="mr-users"></td>
 				</tr>
 				</tr>

--- a/app/views/client/summary_tab.php
+++ b/app/views/client/summary_tab.php
@@ -143,7 +143,7 @@
 				(<span class="mr-console_user"></span>)</td>
 				</tr>
 				<tr>
-					<th data-i18n="user_sessions.uid"></th><td><span class="mr-uid"></span></td>
+					<th data-i18n="user_sessions.last_user_uid"></th><td><span class="mr-uid"></span></td>
 				</tr>
 				<tr>
 					<th data-i18n="user.local_admins"></th><td class="mr-users"></td>

--- a/public/assets/client_installer/reportcommon
+++ b/public/assets/client_installer/reportcommon
@@ -149,13 +149,11 @@ def get_long_username(username):
     return long_name.decode('utf-8')
 
 def get_uid(username):
-    cmd = ['/usr/bin/id', '-u', username]
-    proc = subprocess.Popen(cmd, shell=False, bufsize=-1,
-                            stdin=subprocess.PIPE,
-                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    (output, unused_error) = proc.communicate()
-    output = output.strip()
-    return output
+    try:
+        uid = pwd.getpwnam(username)[2]
+    except:
+        uid = ''
+    return uid
 
 def get_computername():
     cmd = ['/usr/sbin/scutil', '--get', 'ComputerName']

--- a/public/assets/client_installer/reportcommon
+++ b/public/assets/client_installer/reportcommon
@@ -148,6 +148,15 @@ def get_long_username(username):
         long_name = ''
     return long_name.decode('utf-8')
 
+def get_uid(username):
+    cmd = ['/usr/bin/id', '-u', username]
+    proc = subprocess.Popen(cmd, shell=False, bufsize=-1,
+                            stdin=subprocess.PIPE,
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    (output, unused_error) = proc.communicate()
+    output = output.strip()
+    return output
+
 def get_computername():
     cmd = ['/usr/sbin/scutil', '--get', 'ComputerName']
     proc = subprocess.Popen(cmd, shell=False, bufsize=-1,

--- a/public/assets/client_installer/submit.preflight
+++ b/public/assets/client_installer/submit.preflight
@@ -44,6 +44,7 @@ def main():
     report_info = {}
     report_info['console_user'] = "%s" % osutils.getconsoleuser()
     report_info['long_username'] = reportcommon.get_long_username(report_info['console_user'])
+    report_info['uid'] = reportcommon.get_uid(report_info['console_user'])
     report_info['runtype'] = runtype
     report_info['runstate'] = 'done'
     report_info['uptime'] = reportcommon.get_uptime()


### PR DESCRIPTION
Attempt at https://github.com/munkireport/munkireport-php/issues/1057

This PR gathers the UID of users processed in reportdata and user_sessions.
The user_sessions listing, tab, local admin listing, and client summary page have been adjusted to display the UID information.

The added column requires a database migration for reportdata and user_sessions modules.

User sessions client tab:
<img width="1556" alt="screenshot 2018-04-12 09 14 48" src="https://user-images.githubusercontent.com/1416288/38683201-86625936-3e32-11e8-84ba-db3423b4cf94.png">

Client summary:
<img width="521" alt="screenshot 2018-04-12 09 14 56" src="https://user-images.githubusercontent.com/1416288/38683203-86a18f48-3e32-11e8-8996-9c5c7417b614.png">

Local Admin listing:
<img width="1547" alt="screenshot 2018-04-12 09 15 22" src="https://user-images.githubusercontent.com/1416288/38683204-86ba5ef6-3e32-11e8-8a8d-e718ab78242a.png">

User Sessions listing:
<img width="1558" alt="screenshot 2018-04-12 09 16 14" src="https://user-images.githubusercontent.com/1416288/38683205-86e9a508-3e32-11e8-94e3-19e7fe9eecdf.png">

-Eric