### PR TITLE
Realign the Login Page Box

### DIFF
--- a/app/views/auth/login.php
+++ b/app/views/auth/login.php
@@ -1,5 +1,12 @@
 <?php $this->view('partials/head'); ?>
-
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
 	<div class="container">
 		<div class="row">
 			<div class="col-lg-4 col-lg-offset-4">


### PR DESCRIPTION
 The text that pops over the lock icon at the login page is cutoff because the login box is too high up on the page. This PR pushes the login box down a bit so the text is visible. 

There maybe a more appropriate fix than a bunch of `<br>` tags but this works and looks good on a 27" iMac, 15" MBP and iPhone X.

Before: 
<img width="562" alt="lock message cut off" src="https://user-images.githubusercontent.com/815125/38734783-d1cac1fc-3ef4-11e8-80be-b90b3a5b7cda.png">

After:
<img width="584" alt="lock message readable" src="https://user-images.githubusercontent.com/815125/38734793-d9024d32-3ef4-11e8-89b8-b7b12ad41e78.png">

