### PR TITLE
SentinelOne Quarantine module to compliment the SentinelOne module.

### DIFF
--- a/app/modules/sentinelonequarantine/README.md
+++ b/app/modules/sentinelonequarantine/README.md
@@ -1,0 +1,9 @@
+Sentinelone Quarantine module
+================
+
+
+The following information is stored in the sentinelone_quarantine table:
+
+
+* path (string)
+* uuid (string)

--- a/app/modules/sentinelonequarantine/locales/en.json
+++ b/app/modules/sentinelonequarantine/locales/en.json
@@ -1,0 +1,5 @@
+{
+    "path": "Path",
+    "sentinelone_quarantine": "SentinelOne Quarantine",
+    "uuid": "UUID"
+}

--- a/app/modules/sentinelonequarantine/migrations/2018_05_03_152424_sentinelone_add_quarantine_files.php
+++ b/app/modules/sentinelonequarantine/migrations/2018_05_03_152424_sentinelone_add_quarantine_files.php
@@ -1,0 +1,26 @@
+<?php
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Capsule\Manager as Capsule;
+
+class SentineloneAddQuarantineFiles extends Migration
+{
+    public function up()
+    {
+        $capsule = new Capsule();
+        $capsule::schema()->create('sentinelonequarantine', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('serial_number');
+            $table->string('uuid')->nullable();
+            $table->string('path')->nullable();
+
+            $table->index('uuid');
+            $table->index('path');
+    });
+    }
+    public function down()
+    {
+        $capsule = new Capsule();
+        $capsule::schema()->dropIfExists('sentinelonequarantine');
+    }
+}

--- a/app/modules/sentinelonequarantine/provides.php
+++ b/app/modules/sentinelonequarantine/provides.php
@@ -1,0 +1,10 @@
+<?php
+
+return array(
+    'client_tabs' => array(
+      'sentinelonequarantine' => array('view' => 'sentinelone_quarantine_client_tab', 'i18n' => 'sentinelonequarantine.sentinelone_quarantine', 'badge' => 'sentinelonequarantine-cnt'),
+    ),
+    'listings' => array(
+        'sentinelonequarantine' => array('view' => 'sentinelone_quarantine_listing', 'i18n' => 'sentinelonequarantine.sentinelone_quarantine'),
+    ),
+);

--- a/app/modules/sentinelonequarantine/scripts/install.sh
+++ b/app/modules/sentinelonequarantine/scripts/install.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+MODULE_NAME="sentinelonequarantine"
+MODULESCRIPT="sentinelone_quarantine.py"
+QUARANTINE_FILE="sentinelone_quarantine.plist"
+
+CTL="${BASEURL}index.php?/module/${MODULE_NAME}/"
+
+# Get the scripts in the proper directories
+"${CURL[@]}" "${CTL}get_script/${MODULESCRIPT}" -o "${MUNKIPATH}preflight.d/${MODULESCRIPT}"
+
+# Check exit status of curl
+if [ $? = 0 ]; then
+    # Make executable
+    chmod a+x "${MUNKIPATH}preflight.d/${MODULESCRIPT}"
+
+    # Set preference to include the Pref and Quarantine files in the preflight check
+    setreportpref $MODULE_NAME "${CACHEPATH}${QUARANTINE_FILE}"
+
+else
+    echo "Failed to download all required components!"
+    rm -f "${MUNKIPATH}preflight.d/${MODULESCRIPT}"
+
+    # Signal that we had an error
+    ERR=1
+fi

--- a/app/modules/sentinelonequarantine/scripts/sentinelone_quarantine.py
+++ b/app/modules/sentinelonequarantine/scripts/sentinelone_quarantine.py
@@ -39,7 +39,8 @@ def main():
                                 stderr=subprocess.PIPE)
 
         (q_stdout, q_stderr) = task.communicate()
-        
+ 
+        quarantine_list = []
         if "No files quarantined" in q_stdout:
             pass 
         else:
@@ -50,7 +51,6 @@ def main():
             for items in mylist:
                 items[3:] = [''.join(items[3:])]
 
-            quarantine_list = []
             sub_q_dict = {}
         #iterate thru the list of lists
             for i in range(len(mylist)):

--- a/app/modules/sentinelonequarantine/scripts/sentinelone_quarantine.py
+++ b/app/modules/sentinelonequarantine/scripts/sentinelone_quarantine.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python
+
+import subprocess
+import json
+import sys
+import os
+import plistlib
+import dateutil.parser as dp
+import operator
+
+def dict_clean(items):
+    result = {}
+    for key, value in items:
+        if value is None:
+            value = 'None'
+        result[key] = value
+    return result
+
+def main():
+    s1_binary = '/Library/Sentinel/sentinel-agent.bundle/Contents/MacOS/sentinelctl'
+
+    # Skip manual check
+    if len(sys.argv) > 1:
+        if sys.argv[1] == 'manualcheck':
+            print 'Manual check: skipping'
+            exit(0)
+
+    if os.path.isfile(s1_binary):
+        # Create cache dir if it does not exist
+        cachedir = '%s/cache' % os.path.dirname(os.path.realpath(__file__))
+        if not os.path.exists(cachedir):
+            os.makedirs(cachedir)
+
+        # Check if any files are in quarantine
+        
+        quarantine_command = [s1_binary, 'quarantine', 'list', 'files']
+        task = subprocess.Popen(quarantine_command,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+
+        (q_stdout, q_stderr) = task.communicate()
+        
+        if "No files quarantined" in q_stdout:
+            pass 
+        else:
+            lines = q_stdout.splitlines()
+            mylist = [list(thing.split(' ')) for thing in lines]
+
+            # recombine file path since it split at spaces
+            for items in mylist:
+                items[3:] = [''.join(items[3:])]
+
+            quarantine_list = []
+            sub_q_dict = {}
+        #iterate thru the list of lists
+            for i in range(len(mylist)):
+                uuid,path=operator.itemgetter(1,3)(mylist[i])
+                sub_q_dict["uuid"] = uuid
+                sub_q_dict["path"] = path
+                quarantine_list.append(sub_q_dict.copy())
+
+        # Write array of dicts to disk
+        q_output_plist = os.path.join(cachedir, 'sentinelone_quarantine.plist')
+        plistlib.writePlist(quarantine_list, q_output_plist)
+
+    else:
+        print "SentinelOne's sentinelctl binary not found. Exiting."
+        exit(0)
+
+if __name__ == "__main__":
+    main()
+
+

--- a/app/modules/sentinelonequarantine/scripts/uninstall.sh
+++ b/app/modules/sentinelonequarantine/scripts/uninstall.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+MODULESCRIPT="sentinelone_quarantine.py"
+QUARANTINE_CACHE_FILE="sentinelone_quarantine.plist"
+
+# Remove preflight script
+rm -f "${MUNKIPATH}preflight.d/${MODULESCRIPT}"
+
+# Remove cache file
+rm -f "${CACHEPATH}${QUARANTINE_CACHE_FILE}"

--- a/app/modules/sentinelonequarantine/sentinelonequarantine_controller.php
+++ b/app/modules/sentinelonequarantine/sentinelonequarantine_controller.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * SentinelOne Quarantine module class
+ *
+ * @package munkireport
+ * @author
+ **/
+class Sentinelonequarantine_controller extends Module_controller
+{
+    
+    /*** Protect methods with auth! ****/
+    public function __construct()
+    {
+        // Store module path
+        $this->module_path = dirname(__FILE__);
+    }
+    /**
+     * Default method
+     *
+     * @author AvB
+     **/
+    public function index()
+    {
+        echo "You've loaded the sentinelonequarantine module!";
+    }
+    
+    /**
+     * Get sentinelone_quarantine for serial_number
+     *
+     * @param string $serial serial number
+     **/
+    public function get_data($serial_number = '')
+    {
+        $obj = new View();
+
+        if (! $this->authorized()) {
+            $obj->view('json', array('msg' => 'Not authorized'));
+            return;
+        }
+
+        $s1_q = new Sentinelonequarantine_model;
+        $obj->view('json', array('msg' => $s1_q->retrieve_records($serial_number)));
+    }
+
+} // END class default_module

--- a/app/modules/sentinelonequarantine/sentinelonequarantine_model.php
+++ b/app/modules/sentinelonequarantine/sentinelonequarantine_model.php
@@ -1,0 +1,65 @@
+<?php
+
+use CFPropertyList\CFPropertyList;
+
+class Sentinelonequarantine_model extends \Model
+{
+    public function __construct($serial = '')
+    {
+        parent::__construct('id', 'sentinelonequarantine'); //primary key, tablename
+        $this->rs['id'] = '';
+        $this->rs['serial_number'] = $serial;
+        $this->rs['path'] = '';
+        $this->rs['uuid'] = '';
+       
+        if ($serial) {
+            $this->retrieve_record($serial);
+        } 
+        
+    $this->serial_number = $serial;
+    }
+    
+    
+    // ------------------------------------------------------------------------
+	function process($plist)
+	{
+		
+		if ( ! $plist){
+			throw new Exception("Error Processing Request: No property list found", 1);
+		}
+		
+		// Delete previous set        
+		$this->deleteWhere('serial_number=?', $this->serial_number);
+
+		$parser = new CFPropertyList();
+		$parser->parse($plist, CFPropertyList::FORMAT_XML);
+		$myList = $parser->toArray();
+        		
+		$typeList = array(
+			'path' => '',
+			'uuid' => ''
+		);
+		
+		foreach ($myList as $device) {
+			 			
+			// Make sure path is set
+			$device['path'] = isset($device['path']) ? $device['path'] : '';
+            
+			// Make sure uuid is set
+			$device['uuid'] = isset($device['uuid']) ? $device['uuid'] : '';
+            
+			foreach ($typeList as $key => $value) {
+				$this->rs[$key] = $value;
+				if(array_key_exists($key, $device))
+				{
+					$this->rs[$key] = $device[$key];
+				}
+			}
+			
+			// Save device
+			$this->id = '';
+			$this->save();
+		}
+	}
+
+}

--- a/app/modules/sentinelonequarantine/views/sentinelone_quarantine_client_tab.php
+++ b/app/modules/sentinelonequarantine/views/sentinelone_quarantine_client_tab.php
@@ -1,0 +1,51 @@
+<h2 data-i18n="sentinelonequarantine.sentinelone_quarantine"></h2>
+
+
+<table id="sentinelonequarantine-table" class="table table-condensed table-striped">
+    <thead>
+        <tr>
+            <th data-i18n="sentinelonequarantine.path"></th>
+            <th data-i18n="sentinelonequarantine.uuid"></th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td colspan="2" data-i18n="listing.loading"></td>
+        </tr>
+    </tbody>
+</table>
+
+<script>
+
+
+$(document).on('appReady', function(e, lang) {
+
+    // Get certificate data
+    $.getJSON( appUrl + '/module/sentinelonequarantine/get_data/' + serialNumber, function( data ) {
+        // Set count of quarantined files
+        $('#sentinelonequarantine-cnt').text(data.length);
+        if(data.length)
+        {
+            var tbl = $('#sentinelonequarantine-table tbody');
+
+            tbl.empty();
+
+            // Load data
+            $.each(data, function(index, sentinelonequarantine){
+                tbl.append($('<tr>')
+                    .attr('title', sentinelonequarantine.rs.path)
+                    .append($('<td>')
+                        .text(sentinelonequarantine.rs.path))
+                    .append($('<td>')
+                        .text(sentinelonequarantine.rs.uuid)));                      
+            });
+
+
+            // Set correct tab on location hash
+            loadHash();
+
+        }
+    });
+});
+
+</script>

--- a/app/modules/sentinelonequarantine/views/sentinelone_quarantine_listing.php
+++ b/app/modules/sentinelonequarantine/views/sentinelone_quarantine_listing.php
@@ -1,0 +1,96 @@
+<?php $this->view('partials/head'); ?>
+
+<?php //Initialize models needed for the table
+new Machine_model;
+new Reportdata_model;
+new Sentinelonequarantine_model;
+?>
+
+<div class="container">
+
+  <div class="row">
+
+      <div class="col-lg-12">
+
+          <h3><span data-i18n="sentinelonequarantine.sentinelone_quarantine"></span> <span id="total-count" class='label label-primary'>…</span></h3>
+
+          <table class="table table-striped table-condensed table-bordered">
+            <thead>
+              <tr>
+                <th data-i18n="listing.computername" data-colname='machine.computer_name'></th>
+                <th data-i18n="serial" data-colname='reportdata.serial_number'></th>
+                <th data-i18n="username" data-colname='reportdata.long_username'></th>
+                <th data-i18n="sentinelonequarantine.path" data-colname='sentinelonequarantine.path'></th>
+                <th data-i18n="sentinelonequarantine.uuid" data-colname='sentinelonequarantine.uuid'></th>
+              </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td data-i18n="listing.loading" colspan="15" class="dataTables_empty"></td>
+                </tr>
+            </tbody>
+          </table>
+    </div> <!-- /span 12 -->
+  </div> <!-- /row -->
+</div>  <!-- /container -->
+
+<script type="text/javascript">
+
+    $(document).on('appUpdate', function(e){
+
+        var oTable = $('.table').DataTable();
+        oTable.ajax.reload();
+        return;
+
+    });
+
+    $(document).on('appReady', function(e, lang) {
+
+        // Get modifiers from data attribute
+        var mySort = [], // Initial sort
+            hideThese = [], // Hidden columns
+            col = 0, // Column counter
+            runtypes = [], // Array for runtype column
+            columnDefs = [{ visible: false, targets: hideThese }]; //Column Definitions
+
+        $('.table th').map(function(){
+
+            columnDefs.push({name: $(this).data('colname'), targets: col});
+
+            if($(this).data('sort')){
+              mySort.push([col, $(this).data('sort')])
+            }
+
+            if($(this).data('hide')){
+              hideThese.push(col);
+            }
+
+            col++
+        });
+
+        oTable = $('.table').dataTable( {
+            ajax: {
+                url: appUrl + '/datatables/data',
+                type: "POST",
+                data: function(d){
+
+                }
+            },
+            dom: mr.dt.buttonDom,
+            buttons: mr.dt.buttons,
+            order: mySort,
+            columnDefs: columnDefs,
+            createdRow: function( nRow, aData, iDataIndex ) {
+                // Update name in first column to link
+                var name=$('td:eq(0)', nRow).html();
+                if(name == ''){name = "No Name"};
+                var sn=$('td:eq(1)', nRow).html();
+                var link = mr.getClientDetailLink(name, sn, '#tab_sentinelonequarantine');
+                $('td:eq(0)', nRow).html(link);
+
+        }
+    });
+  });
+</script>
+
+<?php $this->view('partials/foot'); ?>


### PR DESCRIPTION
This module can be standalone but only shows the files that are quarantined by SentinelOne. It doesn't include the status of the SentinelOne agent. The `sentinelone` module handles that.

This module only gathers the paths and UUIDs of quarantined files for reference.
Files can be released from quarantine on the client machine by UUID and path, hence having this information handy.

The module includes a Listing:

![screenshot 2018-05-03 22 12 12](https://user-images.githubusercontent.com/1416288/39611670-1d852b16-4f1f-11e8-86c8-ee852e841709.png)

And a client tab view:
![screenshot 2018-05-03 22 13 16](https://user-images.githubusercontent.com/1416288/39611687-3977e782-4f1f-11e8-8cf9-d396a7886a4c.png)

The Tab view includes a badge count to easily see if there are quarantined files from the tab listing:

![screenshot 2018-05-03 22 14 34](https://user-images.githubusercontent.com/1416288/39611703-62709ff8-4f1f-11e8-889d-087cdab271ec.png)
