### PR TITLE
Fix an issue where failed migrations would not display an error

### DIFF
--- a/app/controllers/database.php
+++ b/app/controllers/database.php
@@ -87,8 +87,9 @@ class Database extends Controller
             } catch (\PDOException $exception) {
                 $obj->view('json', [
                     'msg' => [
-                        'notes' => $migrator->getNotes(),
-                        'error' => $exception->getMessage()
+                        'error' => true,
+                        'error_message' => $exception->getMessage(),
+                        'notes' => $migrator->getNotes()
                     ]
                 ]);
             }

--- a/app/views/system/database.php
+++ b/app/views/system/database.php
@@ -85,6 +85,12 @@
           $.getJSON(appUrl + '/database/migrate', function (data) {
             done();
 
+            if (data.notes) {
+              for (var i = 0; i < data.notes.length; i++) {
+                tbody.append($('<tr><td>' + data.notes[i] + '</td></tr>')); // .text(data.notes[i])
+              }
+            }
+
             if (data.error) {
               disclose();
               log(data.error_message, 'error');
@@ -92,19 +98,11 @@
               if (data.error_trace) {
                 log('stack trace follows:', 'error');
                 data.error_trace.forEach(function(stackItem) {
-                  var li = $('<li>in ' + stackItem.file + ':' + stackItem.line + '  ' + stackItem.class + stackItem.type + stackItem.function + '</li>');
                     log('in ' + stackItem.file + ':' + stackItem.line + '  ' + stackItem.class + stackItem.type + stackItem.function + '.' , 'error');
                 });
               }
             }
 
-            if (data.notes) {
-              tbody.empty();
-
-              for (var i = 0; i < data.notes.length; i++) {
-                tbody.append($('<tr><td>' + data.notes[i] + '</td></tr>')); // .text(data.notes[i])
-              }
-            }
         }).fail(function (jqXHR, textStatus, error) {
           done();
         })


### PR DESCRIPTION
The JSON response would be quite different in the PDOException caught vs migration failed error cases which meant that PDOExceptions displayed no information about the error.

This hotfix means that errors are always shown when applying migrations.