### PR TITLE
FIX #1075

### DIFF
--- a/app/lib/munkireport/AbstractAuth.php
+++ b/app/lib/munkireport/AbstractAuth.php
@@ -13,8 +13,8 @@ abstract class AbstractAuth
 
     protected function authorizeUserAndGroups($auth_config, $auth_data)
     {
-        $checkUser = isset($auth_config['mr_allowed_users']);
-        $checkGroups = isset($auth_config['mr_allowed_groups']);
+        $checkUser = !empty($auth_config['mr_allowed_users']);
+        $checkGroups = !empty($auth_config['mr_allowed_groups']);
 
         if( ! $checkUser && ! $checkGroups){
             return true;

--- a/app/lib/munkireport/AuthAD.php
+++ b/app/lib/munkireport/AuthAD.php
@@ -2,7 +2,9 @@
 
 namespace munkireport\lib;
 
-use Adldap\Adldap, \Exception;
+use Adldap\Adldap;
+use Adldap\Schemas\ActiveDirectory as ActiveDirectorySchema;
+use \Exception;
 
 class AuthAD extends AbstractAuth
 {
@@ -17,7 +19,7 @@ class AuthAD extends AbstractAuth
             $this->schema = new $schemaName;
             unset($this->config['schema']);
         } else {
-            $this->schema = new ActiveDirectory;
+            $this->schema = new ActiveDirectorySchema;
         }
         $this->groups = [];
     }
@@ -40,8 +42,12 @@ class AuthAD extends AbstractAuth
                 if($provider->auth()->attempt($login, $password, ! $this->bindAsAdmin())){
                     $search = $provider->search();
 
-                    if ($this->schema instanceof ActiveDirectory) {
-                        $user = $search->users()->findOrFail($login);
+                    if ($this->schema instanceof ActiveDirectorySchema) {
+                        if (empty($this->config['account_suffix'])) {
+                            $user = $search->users()->findByOrFail('userPrincipalName', $login);
+                        } else {
+                            $user = $search->users()->findOrFail($login);
+                        }
                     }
                     else {
                         $user = $search->users()->findByOrFail('uid', $login);

--- a/config/auth_ad.php
+++ b/config/auth_ad.php
@@ -1,8 +1,8 @@
 <?php
 
 return [
-  'account_suffix'           => getenv_default('AUTH_AD_ACCOUNT_SUFFIX', '@mydomain.local'),
-  'base_dn'                  => getenv_default('AUTH_AD_BASE_DN', 'dc=>mydomain,dc=>local'),
+  'account_suffix'           => getenv_default('AUTH_AD_ACCOUNT_SUFFIX', NULL),
+  'base_dn'                  => getenv_default('AUTH_AD_BASE_DN', 'dc=mydomain,dc=local'),
   'domain_controllers'       => getenv_default('AUTH_AD_DOMAIN_CONTROLLERS', [], 'array'),
   'admin_username'           => getenv_default('AUTH_AD_ADMIN_USERNAME', ''),
   'admin_password'           => getenv_default('AUTH_AD_ADMIN_PASSWORD', ''),


### PR DESCRIPTION
AbstractAuth: checking isset() still meant that the default empty array enforced user and group whitelists in AD auth.
AuthAD: Reference to undeclared schema object ActiveDirectory, imported.
AuthAD: NULL account_suffix now means that the user must specify the UPN to log in, otherwise ARN is used.
config/auth_ad.php: defaults are adjusted to be more sensible.