### PR TITLE
FIX #1074: Loop iterated over empty array indices in machine group delete

### DIFF
--- a/app/views/admin/business_units.php
+++ b/app/views/admin/business_units.php
@@ -150,13 +150,14 @@
 		},
 		deleteGroup = function(groupid) // Delete group from machineGroups
 		{
-			// Look for group
-			$.each(machineGroups, function(index, group){
-				if( +group.groupid == +groupid){
-					machineGroups.splice(index, 1);
-					return;
-				}
-			});
+            // Look for group
+		    for (var idx = 0; idx < machineGroups.length; idx++) {
+		      var group = machineGroups[idx];
+		      if (+group.groupid == +groupid) {
+                machineGroups.splice(idx, 1);
+                return;
+              }
+            }
 		},
 		guid = function(){
 


### PR DESCRIPTION
$.each was converted back to old-style for loop because the return; did not shortcut the execution of $.each and caused it to iterate over empty array indices.