### PR TITLE
Support for custom client inactivity

### DIFF
--- a/app/modules/reportdata/reportdata_model.php
+++ b/app/modules/reportdata/reportdata_model.php
@@ -114,12 +114,14 @@ class Reportdata_model extends \Model
         $today = strtotime('today');
         $week_ago = $now - 3600 * 24 * 7;
         $month_ago = $now - 3600 * 24 * 30;
+        $custom_ago = $now - 3600 * 24 * intval(conf('days_inactive'));
         $three_month_ago = $now - 3600 * 24 * 90;
         $sql = "SELECT COUNT(1) as total,
         	COUNT(CASE WHEN timestamp > $hour_ago THEN 1 END) AS lasthour,
         	COUNT(CASE WHEN timestamp > $today THEN 1 END) AS today,
         	COUNT(CASE WHEN timestamp > $week_ago THEN 1 END) AS lastweek,
         	COUNT(CASE WHEN timestamp > $month_ago THEN 1 END) AS lastmonth,
+        	COUNT(CASE WHEN timestamp > $custom_ago THEN 1 END) AS lastcustom,
         	COUNT(CASE WHEN timestamp BETWEEN $month_ago AND $week_ago THEN 1 END) AS inactive_week,
         	COUNT(CASE WHEN timestamp BETWEEN $three_month_ago AND $month_ago THEN 1 END) AS inactive_month,
         	COUNT(CASE WHEN timestamp < $three_month_ago THEN 1 END) AS inactive_three_month

--- a/app/modules/reportdata/views/client_widget.php
+++ b/app/modules/reportdata/views/client_widget.php
@@ -24,7 +24,7 @@ $(document).on('appReady', function() {
 	// Add tooltip
     var inactive_days = "<?php echo conf('days_inactive'); ?>";
 	$('#client-widget>div.panel-heading')
-		.attr('title', (i18n.t('client.panel_title_custom')+" "+inactive_days+" "+i18n.t('date.day_plural')))
+		.attr('title', (i18n.t('client.panel_title')+" "+inactive_days+" "+i18n.t('date.day_plural')))
 		.tooltip();
 
 	var active = i18n.t('active'),

--- a/app/modules/reportdata/views/client_widget.php
+++ b/app/modules/reportdata/views/client_widget.php
@@ -1,29 +1,20 @@
 <div class="col-lg-4 col-md-6">
-
 	<div class="panel panel-default" id="client-widget">
-
 		<div class="panel-heading">
-
 			<h3 class="panel-title"><i class="fa fa-group"></i>
 				<span data-i18n="client.activity"></span>
 				<list-link data-url="/show/listing/reportdata/clients"></list-link>
 			</h3>
-
 		</div>
-
 		<div class="panel-body">
-
 			<svg id="test1" class="center-block" style="width:258px; height: 258px"></svg>
 			<div class="text-muted text-center">
 				<span data-i18n="client.total"></span>: <span class="total-clients"></span> <span class="total-change"></span>
 				|
 				<span data-i18n="client.hour"></span>: <span class="hour-clients"></span> <span class="lasthour-change"></span>
 			</div>
-
 		</div>
-
 	</div>
-
 </div>
 
 <script>
@@ -31,8 +22,9 @@
 $(document).on('appReady', function() {
 
 	// Add tooltip
+    var inactive_days = "<?php echo conf('days_inactive'); ?>";
 	$('#client-widget>div.panel-heading')
-		.attr('title', i18n.t('client.panel_title'))
+		.attr('title', (i18n.t('client.panel_title_custom')+" "+inactive_days+" "+i18n.t('date.day_plural')))
 		.tooltip();
 
 	var active = i18n.t('active'),
@@ -72,9 +64,9 @@ $(document).on('appReady', function() {
 	var drawGraph = function(){
 		var url = appUrl + '/module/reportdata/get_lastseen_stats';
 		d3.json(url, function(data) {
-			testdata1[0].y = data.lastmonth // Active
-			testdata1[1].y = data.total - data.lastmonth // Inactive
-			chart.title("" + data.lastmonth);
+			testdata1[0].y = data.lastcustom // Active
+			testdata1[1].y = data.total - data.lastcustom // Inactive
+			chart.title("" + data.lastcustom);
 
 			d3.select('#test1').datum(testdata1).transition().duration(500).call(chart);
 			chart.update();

--- a/config_default.php
+++ b/config_default.php
@@ -530,6 +530,18 @@
 
 	/*
 	|===============================================
+	| Client inactivity
+	|===============================================
+	|
+	| Set this to be the number of days until a client shows as
+	| being inactive in the round Client Activity widget, defaul is
+	| 30 days.
+	|
+	*/
+	$conf['days_inactive'] = getenv_default(30);
+
+	/*
+	|===============================================
 	| Client passphrases
 	|===============================================
 	|

--- a/config_default.php
+++ b/config_default.php
@@ -534,7 +534,7 @@
 	|===============================================
 	|
 	| Set this to be the number of days until a client shows as
-	| being inactive in the round Client Activity widget, defaul is
+	| being inactive in the round Client Activity widget, default is
 	| 30 days.
 	|
 	*/

--- a/public/assets/locales/en.json
+++ b/public/assets/locales/en.json
@@ -106,6 +106,7 @@
         "comment": "Comments",
         "hour": "Clients per hour",
         "panel_title": "Client activity in the last month",
+        "panel_title_custom": "Client activity in the last",
         "report": "Client Report",
         "tab": {
             "summary": "Summary"

--- a/public/assets/locales/en.json
+++ b/public/assets/locales/en.json
@@ -105,8 +105,7 @@
         "clients": "Clients",
         "comment": "Comments",
         "hour": "Clients per hour",
-        "panel_title": "Client activity in the last month",
-        "panel_title_custom": "Client activity in the last",
+        "panel_title": "Client activity in the last",
         "report": "Client Report",
         "tab": {
             "summary": "Summary"


### PR DESCRIPTION
Added support for changing when a client goes inactive in the Client Activity widget. Configurable in config.php, default is 30 days. Resolves issue #815, requested about 3 times at PSU 2018