### PR TITLE
Update the usb module to collect device product ids

### DIFF
--- a/app/modules/usb/README.md
+++ b/app/modules/usb/README.md
@@ -10,6 +10,7 @@ Database:
 * type - varchar(255) - type of device, manually set via model
 * manufacturer - varchar(255) - reported maker of device
 * vendor_id - varchar(255) - device's vendor ID
+* product_id - varchar(255) - device's product ID
 * device_speed - varchar(255) - USB bus speed
 * internal - int - 0/1 for internal USB device
 * media - int - 0/1 for removable media device

--- a/app/modules/usb/locales/en.json
+++ b/app/modules/usb/locales/en.json
@@ -17,5 +17,6 @@
     "usbtype": "USB Device Types",
     "vendor_id": "Vendor ID",
     "devices": "USB Devices",
-    "report": "USB Report"
+    "report": "USB Report",
+    "product_id": "Product ID"
 }

--- a/app/modules/usb/migrations/2018_07_30_191408_usb_add_product_id.php
+++ b/app/modules/usb/migrations/2018_07_30_191408_usb_add_product_id.php
@@ -1,0 +1,29 @@
+<?php
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Capsule\Manager as Capsule;
+
+class UsbAddProductId extends Migration
+{
+    private $tableName = 'usb';
+
+    public function up()
+    {
+        $capsule = new Capsule();
+        $capsule::schema()->table($this->tableName, function (Blueprint $table) {
+          $table->string('product_id')->nullable();
+
+          $table->index('product_id', 'product_id_index');
+        });
+    }
+
+    public function down()
+    {
+        $capsule = new Capsule();
+        $capsule::schema()->table($this->tableName, function (Blueprint $table) {
+          $table->dropColumn('product_id');
+          
+          $table->dropIndex('product_id_index');
+        });
+    }
+}

--- a/app/modules/usb/migrations/2018_07_30_191408_usb_add_product_id.php
+++ b/app/modules/usb/migrations/2018_07_30_191408_usb_add_product_id.php
@@ -13,7 +13,7 @@ class UsbAddProductId extends Migration
         $capsule::schema()->table($this->tableName, function (Blueprint $table) {
           $table->string('product_id')->nullable();
 
-          $table->index('product_id', 'product_id_index');
+          $table->index('product_id');
         });
     }
 

--- a/app/modules/usb/scripts/usb.py
+++ b/app/modules/usb/scripts/usb.py
@@ -40,6 +40,8 @@ def flatten_usb_info(array):
                 device['name'] = obj[item]
             elif item == 'vendor_id' or item == 'b_vendor_id':
                 device['vendor_id'] = obj[item]
+            elif item == 'product_id':
+                device['product_id'] = obj[item]
             elif item == 'manufacturer' or item == 'f_manufacturer':
                 device['manufacturer'] = obj[item]
             elif item == 'device_speed' or item == 'e_device_speed':

--- a/app/modules/usb/scripts/usb.py
+++ b/app/modules/usb/scripts/usb.py
@@ -40,7 +40,7 @@ def flatten_usb_info(array):
                 device['name'] = obj[item]
             elif item == 'vendor_id' or item == 'b_vendor_id':
                 device['vendor_id'] = obj[item]
-            elif item == 'product_id':
+            elif item == 'product_id' or item == 'a_product_id':
                 device['product_id'] = obj[item]
             elif item == 'manufacturer' or item == 'f_manufacturer':
                 device['manufacturer'] = obj[item]

--- a/app/modules/usb/usb_controller.php
+++ b/app/modules/usb/usb_controller.php
@@ -78,7 +78,7 @@ class Usb_controller extends Module_controller
         
         $queryobj = new Usb_model();
         
-        $sql = "SELECT name, type, manufacturer, vendor_id, device_speed, internal, media, bus_power, bus_power_used, extra_current_used, usb_serial_number
+        $sql = "SELECT name, type, manufacturer, vendor_id, device_speed, internal, media, bus_power, bus_power_used, extra_current_used, usb_serial_number, product_id
                         FROM usb 
                         WHERE serial_number = '$serial_number'";
         

--- a/app/modules/usb/usb_model.php
+++ b/app/modules/usb/usb_model.php
@@ -13,6 +13,7 @@ class Usb_model extends \Model {
 		$this->rs['type'] = ''; // Mouse, Trackpad, Hub, etc.
 		$this->rs['manufacturer'] = '';
 		$this->rs['vendor_id'] = '';
+		$this->rs['product_id'] = '';
 		$this->rs['device_speed'] = ''; // USB Speed
 		$this->rs['internal'] = 0; // True or False
 		$this->rs['media'] = 0; // True or False
@@ -30,6 +31,7 @@ class Usb_model extends \Model {
 		$this->idx[] = array('type');
 		$this->idx[] = array('manufacturer');
 		$this->idx[] = array('vendor_id');
+		$this->idx[] = array('product_id');
 		$this->idx[] = array('device_speed');
 		$this->idx[] = array('internal');
 		$this->idx[] = array('bus_power');
@@ -117,6 +119,7 @@ class Usb_model extends \Model {
 			'type' => 'unknown', // Mouse, Trackpad, Hub, etc.
 			'manufacturer' => '',
 			'vendor_id' => '',
+			'product_id' => '',
 			'device_speed' => '', // Speed
 			'internal' => 0, // True or False
 			'media' => 0, // True or False

--- a/app/modules/usb/views/usb_listing.php
+++ b/app/modules/usb/views/usb_listing.php
@@ -25,6 +25,7 @@ new Usb_model;
 			<th data-i18n="usb.device_speed" data-colname='usb.device_speed'></th>
 			<th data-i18n="usb.internal" data-colname='usb.internal'></th>
 			<th data-i18n="usb.media" data-colname='usb.media'></th>
+			<th data-i18n="usb.product_id" data-colname='usb.product_id'></th>
 		  </tr>
 		</thead>
 

--- a/app/modules/usb/views/usb_listing.php
+++ b/app/modules/usb/views/usb_listing.php
@@ -31,7 +31,7 @@ new Usb_model;
 
 		<tbody>
 		  <tr>
-			<td data-i18n="listing.loading" colspan="9" class="dataTables_empty"></td>
+			<td data-i18n="listing.loading" colspan="10" class="dataTables_empty"></td>
 		  </tr>
 		</tbody>
 


### PR DESCRIPTION
This change allows munkireport to collect the product ids from USB devices. An additional column is added to the usb table called `product_id`. Product ID will be available on the USB listing and on the USB Devices tab for each client. Please shout at me if there are any other changes I need to include.