### PR TITLE
Add x509 cert and private key to SP array for SAML

### DIFF
--- a/app/config/auth/saml.php
+++ b/app/config/auth/saml.php
@@ -4,6 +4,8 @@ return [
   'sp' => [
     'NameIDFormat' => env('AUTH_SAML_SP_NAME_ID_FORMAT', 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'),
     'entityId' => env('AUTH_SAML_SP_ENTITY_ID', ''),
+    'x509cert' => env('AUTH_SAML_SP_X509_CERT', ''),
+    'privateKey' => env('AUTH_SAML_SP_PRIVATE_KEY', ''),
   ],
   'idp' => [
     'entityId' => env('AUTH_SAML_IDP_ENTITY_ID', 'https://app.onelogin.com/saml/metadata/xxxx'),


### PR DESCRIPTION
following the onelogin/php-saml docs (https://github.com/onelogin/php-saml/blob/master/settings_example.php#L66-L67) if you want to have your cert outside of the vendor/onelogin/php-saml/certs folder you should use x509cert and privateKey in the SP array. This PR moves them there and keeps their defaults blank. 

I'm not totally sure that `'cert_directory' => env('AUTH_SAML_CERT_DIR', local_conf('certs/')),` is working correctly as I can't have any value in there not use the local certs dir in the onelogin/php-saml directory.