### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/app/config/auth/ad.php
+++ b/app/config/auth/ad.php
@@ -2,10 +2,10 @@
 
 return [
   'schema'                   => env('AUTH_AD_SCHEMA', 'ActiveDirectory'),
-  'account_prefix'           => env('AUTH_AD_ACCOUNT_PREFIX', NULL),
-  'account_suffix'           => env('AUTH_AD_ACCOUNT_SUFFIX', NULL),
-  'username'                 => env('AUTH_AD_USERNAME', NULL),
-  'password'                 => env('AUTH_AD_PASSWORD', NULL),
+  'account_prefix'           => env('AUTH_AD_ACCOUNT_PREFIX', null),
+  'account_suffix'           => env('AUTH_AD_ACCOUNT_SUFFIX', null),
+  'username'                 => env('AUTH_AD_USERNAME', null),
+  'password'                 => env('AUTH_AD_PASSWORD', null),
   'base_dn'                  => env('AUTH_AD_BASE_DN', 'dc=mydomain,dc=local'),
   'hosts'                    => env('AUTH_AD_HOSTS', []),
   'port'                     => env('AUTH_AD_PORT', 389),

--- a/app/lib/authLDAP/authLDAP.php
+++ b/app/lib/authLDAP/authLDAP.php
@@ -77,7 +77,7 @@ class Auth_ldap
      **/
     public function getConf($value='')
     {
-        return isset($this->conf[$value]) ? $this->conf[$value] : FALSE;
+        return isset($this->conf[$value]) ? $this->conf[$value] : false;
     }
 
     /**


### PR DESCRIPTION
Hi, I've changed some PHP keywords to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!