### PR TITLE
Add note about modules to contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ Contributing
 If you want to contribute to munkireport2, please 
 
 * read about [Localizing](docs/localize.md) in the docs folder
+* check the [modules overview](https://github.com/munkireport/munkireport-php/wiki/Module-Overview) for info about installing and creating modules
 * fork the [wip branch of repository](https://github.com/munkireport/munkireport-php/tree/wip)
 * create a feature branch
 * send a pull request with your changes.
-
 
 External projects
 ---


### PR DESCRIPTION
When I was looking through the code I was a bit confused because I couldn't find the modules anymore. The old module creation page says the method is deprecated and needs to be updated but doesn't link to the new [module overview](https://github.com/munkireport/munkireport-php/wiki/Module-Overview) page that describes the changes.

I added a small note about modules in the contributing section of the README.md. This should help guide people that are interested in contributing to the modules.

I was also thinking of adding a note and link to the top of these wiki pages, but I didn't want to change without approval.

- [How to create a module](https://github.com/munkireport/munkireport-php/wiki/How-to-create-a-module)
- [How to create a module - advanced](https://github.com/munkireport/munkireport-php/wiki/How-to-create-a-module-%28advanced%29)

Thanks to all the contributors for all their amazing work!