### PR TITLE
Remove duplicate hosts key

### DIFF
--- a/build/config/config_to_env.yml
+++ b/build/config/config_to_env.yml
@@ -69,7 +69,6 @@ auth:
     base_dn: AUTH_AD_BASE_DN
     hosts: AUTH_AD_HOSTS
     domain_controllers: AUTH_AD_HOSTS
-    hosts: AUTH_AD_HOSTS
     port: AUTH_AD_PORT
     follow_referrals: AUTH_AD_FOLLOW_REFERRALS
     use_ssl: AUTH_AD_USE_SSL


### PR DESCRIPTION
There were two instances of the `hosts` key in the config_to_env.yml file. This change removes one of them.