### PR TITLE
Add pre-commit hooks for PHP linting, Python Black, and other basics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
   - id: check-case-conflict
   # - id: check-docstring-first
   # - id: check-executables-have-shebangs
+  - id: check-json
   - id: check-merge-conflict
   # - id: check-yaml
   # - id: end-of-file-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
   # - id: check-executables-have-shebangs
   - id: check-json
   - id: check-merge-conflict
+  - id: check-xml
   # - id: check-yaml
   # - id: end-of-file-fixer
   - id: mixed-line-ending

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.2.3
+  hooks:
+  - id: check-added-large-files
+    args: [--maxkb=100]
+  - id: check-ast
+  - id: check-byte-order-marker
+  - id: check-case-conflict
+  # - id: check-docstring-first
+  # - id: check-executables-have-shebangs
+  - id: check-merge-conflict
+  # - id: check-yaml
+  # - id: end-of-file-fixer
+  - id: mixed-line-ending
+  # - id: trailing-whitespace
+  #   args: [--markdown-linebreak-ext=md]
+- repo: https://github.com/digitalpulp/pre-commit-php
+  rev: 1.3.0
+  hooks:
+  - id: php-lint-all
+- repo: https://github.com/python/black
+  rev: 19.3b0
+  hooks:
+  - id: black

--- a/build/release/make_munkireport_release.py
+++ b/build/release/make_munkireport_release.py
@@ -13,7 +13,7 @@
 # Requires an OAuth token with push access to the repo. Currently the GitHub
 # Releases API is in a 'preview' status, and this script does very little error
 # handling.
-"""See docstring for main() function"""
+"""See docstring for main() function."""
 
 import json
 import optparse
@@ -31,7 +31,7 @@ from time import strftime
 
 
 class GitHubAPIError(BaseException):
-    """Base error for GitHub API interactions"""
+    """Base error for GitHub API interactions."""
 
     pass
 
@@ -128,26 +128,23 @@ def run_command(cmd):
 
 
 def main():
-    """Builds and pushes a new munkireport-php release from an existing Git clone
-of munkireport-php.
+    """Builds and pushes a new munkireport-php release from an existing Git
+    clone of munkireport-php.
 
-Requirements:
+    Requirements:
 
-API token:
-You'll need an API OAuth token with push access to the repo. You can create a
-Personal Access Token in your user's Account Settings:
-https://github.com/settings/applications
-
-"""
+    API token:
+    You'll need an API OAuth token with push access to the repo. You can create a
+    Personal Access Token in your user's Account Settings:
+    https://github.com/settings/applications
+    """
     usage = __doc__
     parser = optparse.OptionParser(usage=usage)
     parser.add_option("-t", "--token", help="GitHub API OAuth token. Required.")
     parser.add_option(
         "-v",
         "--next-version",
-        help=(
-            "Next version to which munkireport-php will be " "incremented. Required."
-        ),
+        help=("Next version to which munkireport-php will be incremented. Required."),
     )
     parser.add_option(
         "-p",

--- a/build/release/make_munkireport_release.py
+++ b/build/release/make_munkireport_release.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 #
 # Script to run the munkireport-php GitHub release workflow as outlined here:
-#https://github.com/autopkg/autopkg/wiki/Packaging-AutoPkg-For-Release-on-GitHub
+# https://github.com/autopkg/autopkg/wiki/Packaging-AutoPkg-For-Release-on-GitHub
 #
 # This includes tagging and setting appropriate release notes for the release,
 # uploading the actual built package, and incrementing the version number for
@@ -13,7 +13,7 @@
 # Requires an OAuth token with push access to the repo. Currently the GitHub
 # Releases API is in a 'preview' status, and this script does very little error
 # handling.
-'''See docstring for main() function'''
+"""See docstring for main() function"""
 
 import json
 import optparse
@@ -24,30 +24,39 @@ import subprocess
 import sys
 import tempfile
 import urllib2
-
 from distutils.version import LooseVersion
 from pprint import pprint
 from shutil import rmtree
 from time import strftime
 
+
 class GitHubAPIError(BaseException):
-    '''Base error for GitHub API interactions'''
+    """Base error for GitHub API interactions"""
+
     pass
 
 
-def api_call(endpoint, token, baseurl='https://api.github.com', data=None,
-             json_data=True, additional_headers=None):
-    '''endpoint: of the form '/repos/username/repo/etc'.
+def api_call(
+    endpoint,
+    token,
+    baseurl="https://api.github.com",
+    data=None,
+    json_data=True,
+    additional_headers=None,
+):
+    """endpoint: of the form '/repos/username/repo/etc'.
     token: the API token for Authorization.
     baseurl: the base URL for the API endpoint. for asset uploads this ends up
              needing to be overridden.
     data: takes a standard python object and serializes to json for a POST,
           unless json_data is False.
-    additional_headers: a dict of additional headers for the API call'''
+    additional_headers: a dict of additional headers for the API call"""
     if data and json_data:
         data = json.dumps(data, ensure_ascii=False)
-    headers = {'Accept': 'application/vnd.github.v3+json',
-               'Authorization': 'token %s' % token}
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+        "Authorization": "token %s" % token,
+    }
     if additional_headers:
         for header, value in additional_headers.items():
             headers[header] = value
@@ -56,26 +65,29 @@ def api_call(endpoint, token, baseurl='https://api.github.com', data=None,
     try:
         results = urllib2.urlopen(req, data=data)
     except urllib2.HTTPError as err:
-        print >> sys.stderr, "HTTP error making API call!"
-        print >> sys.stderr, err
+        print >>sys.stderr, "HTTP error making API call!"
+        print >>sys.stderr, err
         error_json = err.read()
         error = json.loads(error_json)
-        print >> sys.stderr, "API message: %s" % error['message']
+        print >>sys.stderr, "API message: %s" % error["message"]
         sys.exit(1)
     if results:
         try:
             parsed = json.loads(results.read())
             return parsed
         except BaseException as err:
-            print >> sys.stderr, err
+            print >>sys.stderr, err
             raise GitHubAPIError
     return None
 
+
 def get_version_file_path():
-    return 'app/helpers/site_helper.php'
+    return "app/helpers/site_helper.php"
+
 
 def get_commit_count():
     return int(get_version(True))
+
 
 def get_version(commit_count=False):
     try:
@@ -86,29 +98,34 @@ def get_version(commit_count=False):
             pattern = re.compile("\$GLOBALS\['version'\] = '(.+)\.\d+'")
         for i, line in enumerate(open(helper)):
             for match in re.finditer(pattern, line):
-                return '%s' % match.groups()
+                return "%s" % match.groups()
     except BaseException:
         sys.exit("Couldn't determine current munkireport-php version!")
+
 
 def clean_version(version):
     return re.sub("[^0-9\.].*", "", version)
 
+
 def set_version(version):
     helper = get_version_file_path()
     search = "(\$GLOBALS\['version'\] = ')[^']+"
-    replace = r'\g<1>%s' % version
-    with open(helper, 'r+') as f:
+    replace = r"\g<1>%s" % version
+    with open(helper, "r+") as f:
         content = re.sub(search, replace, f.read())
         f.seek(0)
         f.truncate()
         f.write(content)
 
+
 def get_version_from_string(str):
     return str.split(" ", 1)[0]
 
+
 def run_command(cmd):
-    print ' '.join(cmd)
+    print(" ".join(cmd))
     subprocess.check_call(cmd)
+
 
 def main():
     """Builds and pushes a new munkireport-php release from an existing Git clone
@@ -124,24 +141,42 @@ https://github.com/settings/applications
 """
     usage = __doc__
     parser = optparse.OptionParser(usage=usage)
-    parser.add_option('-t', '--token',
-                      help="GitHub API OAuth token. Required.")
-    parser.add_option('-v', '--next-version',
-                      help=("Next version to which munkireport-php will be "
-                            "incremented. Required."))
-    parser.add_option('-p', '--prerelease',
-                      help=("Mark this release as a pre-release, applying "
-                            "a given suffix to the tag, i.e. 'RC1'"))
-    parser.add_option('--dry-run', action='store_true',
-                      help=("Don't actually push any changes to "
-                            "Git remotes, and skip the actual release "
-                            "creation. Useful for testing changes "
-                            "to this script. Any GitHub API calls made "
-                            "are read-only."))
-    parser.add_option('--user-repo', default='munkireport/munkireport-php',
-                      help=("Alternate org/user and repo to use for "
-                            "the release, useful for testing. Defaults to "
-                            "'munkireport/munkireport-php'."))
+    parser.add_option("-t", "--token", help="GitHub API OAuth token. Required.")
+    parser.add_option(
+        "-v",
+        "--next-version",
+        help=(
+            "Next version to which munkireport-php will be " "incremented. Required."
+        ),
+    )
+    parser.add_option(
+        "-p",
+        "--prerelease",
+        help=(
+            "Mark this release as a pre-release, applying "
+            "a given suffix to the tag, i.e. 'RC1'"
+        ),
+    )
+    parser.add_option(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Don't actually push any changes to "
+            "Git remotes, and skip the actual release "
+            "creation. Useful for testing changes "
+            "to this script. Any GitHub API calls made "
+            "are read-only."
+        ),
+    )
+    parser.add_option(
+        "--user-repo",
+        default="munkireport/munkireport-php",
+        help=(
+            "Alternate org/user and repo to use for "
+            "the release, useful for testing. Defaults to "
+            "'munkireport/munkireport-php'."
+        ),
+    )
 
     opts = parser.parse_args()[0]
     if not opts.next_version:
@@ -150,124 +185,133 @@ https://github.com/settings/applications
         sys.exit("Option --token is required!")
     next_version = opts.next_version
     if opts.dry_run:
-        print "Running in 'dry-run' mode.."
-    publish_user, publish_repo = opts.user_repo.split('/')
+        print("Running in 'dry-run' mode..")
+    publish_user, publish_repo = opts.user_repo.split("/")
     token = opts.token
 
     # ensure our OAuth token works before we go any further
-    api_call('/users/%s' % publish_user, token)
+    api_call("/users/%s" % publish_user, token)
 
     # set up some paths and important variables
-    munkireport_root = tempfile.mkdtemp('', 'mr_release_')
-    changelog_path = os.path.join(munkireport_root, 'CHANGELOG.md')
+    munkireport_root = tempfile.mkdtemp("", "mr_release_")
+    changelog_path = os.path.join(munkireport_root, "CHANGELOG.md")
 
     # clone Git master
     run_command(
-        ['git', 'clone', #'--depth',  '1',
-         'https://github.com/%s/%s' % (publish_user, publish_repo),
-         munkireport_root])
+        [
+            "git",
+            "clone",  #'--depth',  '1',
+            "https://github.com/%s/%s" % (publish_user, publish_repo),
+            munkireport_root,
+        ]
+    )
     os.chdir(munkireport_root)
-    
-    branch = 'wip'
-    
-    run_command(['git', 'checkout', branch])
-        
+
+    branch = "wip"
+
+    run_command(["git", "checkout", branch])
+
     # get the current munkireport-php version
     current_version = get_version()
-    tag_name = 'v%s' % current_version
+    tag_name = "v%s" % current_version
     if opts.prerelease:
         tag_name += opts.prerelease
         current_version += opts.prerelease
 
-    # print "Current munkireport-php version: %s" % current_version
+    # print("Current munkireport-php version: %s" % current_version)
     # if LooseVersion(next_version) < LooseVersion(current_version):
     #     sys.exit(
     #         "Next version (gave %s) must be greater than current version %s!"
     #         % (next_version, current_version))
 
     published_releases = api_call(
-        '/repos/%s/%s/releases' % (publish_user, publish_repo), token)
+        "/repos/%s/%s/releases" % (publish_user, publish_repo), token
+    )
     for rel in published_releases:
-        if rel['tag_name'] == tag_name:
-            print >> sys.stderr, (
+        if rel["tag_name"] == tag_name:
+            print >>sys.stderr, (
                 "There's already a published release on GitHub with the tag "
                 "{0}. It should first be manually removed. "
-                "Release data printed below:".format(tag_name))
+                "Release data printed below:".format(tag_name)
+            )
             pprint(rel, stream=sys.stderr)
             sys.exit()
 
     # write today's date in the changelog
-    with open(changelog_path, 'r') as fdesc:
+    with open(changelog_path, "r") as fdesc:
         changelog = fdesc.read()
-    release_date = strftime('(%B %d, %Y)')
-    new_changelog = re.sub(r'### \[.+\]', '### [%s]' % current_version, changelog, 1)
-    new_changelog = re.sub(r'\(Unreleased\)', release_date, new_changelog)
-    new_changelog = re.sub('...HEAD', '...v%s' % current_version, new_changelog)
-    with open(changelog_path, 'w') as fdesc:
+    release_date = strftime("(%B %d, %Y)")
+    new_changelog = re.sub(r"### \[.+\]", "### [%s]" % current_version, changelog, 1)
+    new_changelog = re.sub(r"\(Unreleased\)", release_date, new_changelog)
+    new_changelog = re.sub("...HEAD", "...v%s" % current_version, new_changelog)
+    with open(changelog_path, "w") as fdesc:
         fdesc.write(new_changelog)
 
     # commit and push the new release
-    run_command(['git', 'add', changelog_path])
-    run_command(
-        ['git', 'commit', '-m', 'Release version %s.' % current_version])
-    run_command(['git', 'tag', tag_name])
+    run_command(["git", "add", changelog_path])
+    run_command(["git", "commit", "-m", "Release version %s." % current_version])
+    run_command(["git", "tag", tag_name])
     if not opts.dry_run:
-        run_command(['git', 'push', 'origin', branch])
-        run_command(['git', 'push', '--tags', 'origin', branch])
+        run_command(["git", "push", "origin", branch])
+        run_command(["git", "push", "--tags", "origin", branch])
 
     # extract release notes for this new version
     notes_rex = r"(?P<current_ver_notes>\#\#\# \[.+?)\#\#\#"
     match = re.search(notes_rex, new_changelog, re.DOTALL)
     if not match:
         sys.exit("Couldn't extract release notes for this version!")
-    release_notes = match.group('current_ver_notes')
+    release_notes = match.group("current_ver_notes")
 
     # prepare release metadata
     release_data = dict()
-    release_data['tag_name'] = tag_name
-    release_data['target_commitish'] = branch
-    release_data['name'] = "Munkireport " + current_version
-    release_data['body'] = release_notes
-    release_data['draft'] = False
+    release_data["tag_name"] = tag_name
+    release_data["target_commitish"] = branch
+    release_data["name"] = "Munkireport " + current_version
+    release_data["body"] = release_notes
+    release_data["draft"] = False
     if opts.prerelease:
-        release_data['prerelease'] = True
+        release_data["prerelease"] = True
 
     # create the release
     if not opts.dry_run:
         create_release = api_call(
-            '/repos/%s/%s/releases' % (publish_user, publish_repo),
+            "/repos/%s/%s/releases" % (publish_user, publish_repo),
             token,
-            data=release_data)
+            data=release_data,
+        )
         if create_release:
-            print "Release successfully created. Server response:"
+            print("Release successfully created. Server response:")
             pprint(create_release)
             print
 
     # increment version
-    print "Incrementing version to %s.." % next_version
-    set_version('%s.%s' % (clean_version(next_version), get_commit_count() + 1))
+    print("Incrementing version to %s.." % next_version)
+    set_version("%s.%s" % (clean_version(next_version), get_commit_count() + 1))
 
     # increment changelog
-    new_changelog = "### [{0}](https://github.com/{1}/{2}/compare/v{3}...HEAD) (Unreleased)\n\n".format(
-        next_version,
-        publish_user,
-        publish_repo,
-        current_version) + new_changelog
-    with open(changelog_path, 'w') as fdesc:
+    new_changelog = (
+        "### [{0}](https://github.com/{1}/{2}/compare/v{3}...HEAD) (Unreleased)\n\n".format(
+            next_version, publish_user, publish_repo, current_version
+        )
+        + new_changelog
+    )
+    with open(changelog_path, "w") as fdesc:
         fdesc.write(new_changelog)
 
     # commit and push increment
-    run_command(['git', 'add', get_version_file_path(), changelog_path])
+    run_command(["git", "add", get_version_file_path(), changelog_path])
     run_command(
-        ['git', 'commit', '-m',
-         'Bumping to v%s for development.' % next_version])
+        ["git", "commit", "-m", "Bumping to v%s for development." % next_version]
+    )
     if not opts.dry_run:
-        run_command(['git', 'push', 'origin', branch])
+        run_command(["git", "push", "origin", branch])
     else:
-        print ("Ended dry-run mode. Final state of the munkireport-php repo can be "
-               "found at: %s" % munkireport_root)
+        print(
+            "Ended dry-run mode. Final state of the munkireport-php repo can be "
+            "found at: %s" % munkireport_root
+        )
     # clean up
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/build/update_bootstrap.py
+++ b/build/update_bootstrap.py
@@ -1,25 +1,31 @@
 #!/usr/bin/python
 
-import os
 import json
-import subprocess
+import os
 import re
+import subprocess
+
 
 def curl(url):
-    p1 = subprocess.Popen(['curl', '--silent', url], stdout=subprocess.PIPE)
+    p1 = subprocess.Popen(["curl", "--silent", url], stdout=subprocess.PIPE)
     return p1.communicate()[0]
 
+
 def find_body_color(css_data):
-    urls = re.findall(r'body.*{[^}]+\scolor:\s?(.+);', css_data)
+    urls = re.findall(r"body.*{[^}]+\scolor:\s?(.+);", css_data)
     return urls[0]
-    
+
+
 def find_background_color(css_data):
-    urls = re.findall(r'body.*{[^}]+\sbackground-color:\s?(.+);', css_data)
+    urls = re.findall(r"body.*{[^}]+\sbackground-color:\s?(.+);", css_data)
     return urls[0]
+
 
 def write_override(fileName, bodyColor, backgroundColor):
     with open(fileName, "w+") as f:
-        f.write("text, svg .nvd3.nv-pie .nv-pie-title, .nvd3 .nv-discretebar .nv-groups text, .nvd3 .nv-multibarHorizontal .nv-groups text{\n")
+        f.write(
+            "text, svg .nvd3.nv-pie .nv-pie-title, .nvd3 .nv-discretebar .nv-groups text, .nvd3 .nv-multibarHorizontal .nv-groups text{\n"
+        )
         f.write("   fill: %s;\n" % bodyColor)
         f.write("}\n")
         f.write(".nvd3 .nv-axis path{stroke: %s}\n" % bodyColor)
@@ -30,49 +36,51 @@ def write_override(fileName, bodyColor, backgroundColor):
         f.write("}\n")
 
 
-bootstrap_base_url='https://raw.githubusercontent.com/twbs/bootstrap/master/dist/'
-bootswatch_url='https://bootswatch.com/api/3.json'
+bootstrap_base_url = "https://raw.githubusercontent.com/twbs/bootstrap/master/dist/"
+bootswatch_url = "https://bootswatch.com/api/3.json"
 basedir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
-print 'Getting bootstrap files'
-css = curl(bootstrap_base_url + 'css/bootstrap.min.css')
-with open(os.path.join(basedir, 'assets', 'themes', 'Default', 'bootstrap.min.css'),"w+") as f:
+print("Getting bootstrap files")
+css = curl(bootstrap_base_url + "css/bootstrap.min.css")
+with open(
+    os.path.join(basedir, "assets", "themes", "Default", "bootstrap.min.css"), "w+"
+) as f:
     f.write(css)
-js = curl(bootstrap_base_url + 'js/bootstrap.min.js')
-with open(os.path.join(basedir, 'assets', 'js', 'bootstrap.min.js'),"w+") as f:
+js = curl(bootstrap_base_url + "js/bootstrap.min.js")
+with open(os.path.join(basedir, "assets", "js", "bootstrap.min.js"), "w+") as f:
     f.write(js)
-fileName = os.path.join(basedir, 'assets', 'themes', 'Default', 'nvd3.override.css')
-write_override(fileName, '#333', '#fff')
+fileName = os.path.join(basedir, "assets", "themes", "Default", "nvd3.override.css")
+write_override(fileName, "#333", "#fff")
 
-print 'Getting themes'
+print("Getting themes")
 jsondata = curl(bootswatch_url)
 data = json.loads(jsondata)
 
-for item in data['themes']:
-    item_dir = os.path.join(basedir, 'assets', 'themes', item['name'])
+for item in data["themes"]:
+    item_dir = os.path.join(basedir, "assets", "themes", item["name"])
     if not os.path.isdir(item_dir):
         os.mkdir(item_dir)
-    
+
     # Get css
-    print 'Updating %s' % item['name']
-    css_data = curl(item['cssMin'])
-    
-    with open(os.path.join(item_dir, 'bootstrap.min.css'),"w+") as f:
+    print("Updating %s" % item["name"])
+    css_data = curl(item["cssMin"])
+
+    with open(os.path.join(item_dir, "bootstrap.min.css"), "w+") as f:
         f.write(css_data)
 
-print 'Creating nvd3 styles'
-for item in data['themes']:
-    item_dir = os.path.join(basedir, 'assets', 'themes', item['name'])
+print("Creating nvd3 styles")
+for item in data["themes"]:
+    item_dir = os.path.join(basedir, "assets", "themes", item["name"])
     if not os.path.isdir(item_dir):
         os.mkdir(item_dir)
-    
+
     # Get css
-    print 'Updating %s' % item['name']
-    css_data = curl(item['css'])
-    
+    print("Updating %s" % item["name"])
+    css_data = curl(item["css"])
+
     bodyColor = find_body_color(css_data)
     backgroundColor = find_background_color(css_data)
 
-    print 'color: %s; background-color: %s' % (bodyColor, backgroundColor)
-    fileName = os.path.join(item_dir, 'nvd3.override.css')
+    print("color: %s; background-color: %s" % (bodyColor, backgroundColor))
+    fileName = os.path.join(item_dir, "nvd3.override.css")
     write_override(fileName, bodyColor, backgroundColor)

--- a/public/assets/client_installer/postflight
+++ b/public/assets/client_installer/postflight
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 # encoding: utf-8
-'''Postflight script'''
+"""Postflight script"""
 
 try:
     from munkilib import info
@@ -16,17 +16,18 @@ import hashlib
 import sys
 import os
 
+
 def main():
-    '''Main'''
+    """Main"""
     # get runtype
-    if (len(sys.argv) > 1):
+    if len(sys.argv) > 1:
         runtype = sys.argv[1]
     else:
-        runtype = 'custom'
+        runtype = "custom"
 
     # Try to get the munki verbosity level
-    verbosity = os.environ.get('MUNKI_VERBOSITY_LEVEL')
-    if (verbosity):
+    verbosity = os.environ.get("MUNKI_VERBOSITY_LEVEL")
+    if verbosity:
         reportcommon.set_verbosity(int(verbosity))
     else:
         reportcommon.set_verbosity(3)
@@ -39,40 +40,44 @@ def main():
 
     # Get serial
     hardware_info = info.get_hardware_info()
-    hardware_info['computer_name'] = reportcommon.get_computername()
-    hardware_info['cpu'] = reportcommon.get_cpuinfo()
-    hardware_info['cpu_arch'] = os.uname()[4]
-    hardware_info['hostname'] = os.uname()[1]
-    hardware_info['os_version'] = \
-        osutils.getOsVersion(only_major_minor=False)
-    hardware_info['buildversion'] = \
-        reportcommon.get_buildversion()
-    serial = hardware_info.get('serial_number', 'NO_SERIAL')
+    hardware_info["computer_name"] = reportcommon.get_computername()
+    hardware_info["cpu"] = reportcommon.get_cpuinfo()
+    hardware_info["cpu_arch"] = os.uname()[4]
+    hardware_info["hostname"] = os.uname()[1]
+    hardware_info["os_version"] = osutils.getOsVersion(only_major_minor=False)
+    hardware_info["buildversion"] = reportcommon.get_buildversion()
+    serial = hardware_info.get("serial_number", "NO_SERIAL")
     hw_info_plist = FoundationPlist.writePlistToString(hardware_info)
 
-    items = {} # item list
+    items = {}  # item list
     report_info = {}
-    report_info['console_user'] = "%s" % osutils.getconsoleuser()
-    report_info['runtype'] = runtype
-    report_info['runstate'] = 'done'
-    report_info['uptime'] = reportcommon.get_uptime()
+    report_info["console_user"] = "%s" % osutils.getconsoleuser()
+    report_info["runtype"] = runtype
+    report_info["runstate"] = "done"
+    report_info["uptime"] = reportcommon.get_uptime()
     report_info_plist = FoundationPlist.writePlistToString(report_info)
-    items = {'machine': \
-        {'hash':hashlib.md5(hw_info_plist).hexdigest(), 'data':hw_info_plist}, \
-            'reportdata': \
-        {'hash':hashlib.md5(report_info_plist).hexdigest(), \
-            'data':report_info_plist}}
-    
+    items = {
+        "machine": {
+            "hash": hashlib.md5(hw_info_plist).hexdigest(),
+            "data": hw_info_plist,
+        },
+        "reportdata": {
+            "hash": hashlib.md5(report_info_plist).hexdigest(),
+            "data": report_info_plist,
+        },
+    }
+
     # Read config file /Library/Preferences/Munkireport.plist
-    config_items = reportcommon.pref('ReportItems') or {}
+    config_items = reportcommon.pref("ReportItems") or {}
 
     for key, val in config_items.items():
         reportcommon.display_detail("Requesting %s" % key)
-        items[key] = {'path':val}
+        items[key] = {"path": val}
 
     reportcommon.process(serial, items)
 
     exit(0)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/public/assets/client_installer/preflight
+++ b/public/assets/client_installer/preflight
@@ -1,28 +1,29 @@
 #!/usr/bin/python
 # encoding: utf-8
-''' Preflight script'''
+""" Preflight script"""
 import sys
 import os
 from munkilib import reportcommon
 
+
 def main():
-    '''Main'''
+    """Main"""
     # Munkireport submit script TODO: make config item
-    submitscript = 'submit.preflight'
+    submitscript = "submit.preflight"
 
     # Try to get the munki verbosity level
-    verbosity = os.environ.get('MUNKI_VERBOSITY_LEVEL')
-    if (verbosity):
+    verbosity = os.environ.get("MUNKI_VERBOSITY_LEVEL")
+    if verbosity:
         reportcommon.set_verbosity(int(verbosity))
     else:
         reportcommon.set_verbosity(3)
 
     # get runtype
-    if (len(sys.argv) > 1):
+    if len(sys.argv) > 1:
         runtype = sys.argv[1]
     else:
-        runtype = 'custom'
-    
+        runtype = "custom"
+
     # define path to directory with preflight scripts
     scriptdir = os.path.realpath(os.path.dirname(sys.argv[0]))
 
@@ -33,8 +34,9 @@ def main():
     # Try to run preflight.d
     preflightscriptdir = os.path.join(scriptdir, "preflight.d")
     reportcommon.rundir(preflightscriptdir, runtype, False, submitscript)
-    
+
     exit(0)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/public/assets/client_installer/submit.preflight
+++ b/public/assets/client_installer/submit.preflight
@@ -1,12 +1,12 @@
 #!/usr/bin/python
 # encoding: utf-8
-''' Preflight script'''
+""" Preflight script"""
 
 import hashlib
 import sys
 import os
 
-sys.path.insert(0,'/usr/local/munki') # TODO: make this relative
+sys.path.insert(0, "/usr/local/munki")  # TODO: make this relative
 
 try:
     from munkilib import info
@@ -15,50 +15,57 @@ except ImportError:
     # Legacy support
     from munkilib import munkicommon as info
     from munkilib import munkicommon as osutils
-    
+
 from munkilib import reportcommon
 from munkilib import FoundationPlist
 
+
 def main():
-    '''Main'''
+    """Main"""
     # get runtype
-    if (len(sys.argv) > 1):
+    if len(sys.argv) > 1:
         runtype = sys.argv[1]
     else:
-        runtype = 'custom'
+        runtype = "custom"
 
     # Collect some hardware info
     hardware_info = info.get_hardware_info()
-    hardware_info['computer_name'] = reportcommon.get_computername()
-    hardware_info['cpu'] = reportcommon.get_cpuinfo()
-    hardware_info['cpu_arch'] = os.uname()[4]
-    hardware_info['hostname'] = os.uname()[1]
-    hardware_info['os_version'] = \
-        osutils.getOsVersion(only_major_minor=False)
-    hardware_info['buildversion'] = \
-        reportcommon.get_buildversion()
-    serial = hardware_info.get('serial_number', 'NO_SERIAL')
+    hardware_info["computer_name"] = reportcommon.get_computername()
+    hardware_info["cpu"] = reportcommon.get_cpuinfo()
+    hardware_info["cpu_arch"] = os.uname()[4]
+    hardware_info["hostname"] = os.uname()[1]
+    hardware_info["os_version"] = osutils.getOsVersion(only_major_minor=False)
+    hardware_info["buildversion"] = reportcommon.get_buildversion()
+    serial = hardware_info.get("serial_number", "NO_SERIAL")
     hw_info_plist = FoundationPlist.writePlistToString(hardware_info)
 
     # Collect some report info
     report_info = {}
-    report_info['console_user'] = "%s" % osutils.getconsoleuser()
-    report_info['long_username'] = reportcommon.get_long_username(report_info['console_user'])
-    report_info['uid'] = reportcommon.get_uid(report_info['console_user'])
-    report_info['runtype'] = runtype
-    report_info['runstate'] = 'done'
-    report_info['uptime'] = reportcommon.get_uptime()
+    report_info["console_user"] = "%s" % osutils.getconsoleuser()
+    report_info["long_username"] = reportcommon.get_long_username(
+        report_info["console_user"]
+    )
+    report_info["uid"] = reportcommon.get_uid(report_info["console_user"])
+    report_info["runtype"] = runtype
+    report_info["runstate"] = "done"
+    report_info["uptime"] = reportcommon.get_uptime()
     report_info_plist = FoundationPlist.writePlistToString(report_info)
 
-    items = {'machine': \
-        {'hash':hashlib.md5(hw_info_plist).hexdigest(), 'data':hw_info_plist}, \
-            'reportdata': \
-        {'hash':hashlib.md5(report_info_plist).hexdigest(), \
-            'data':report_info_plist}}
+    items = {
+        "machine": {
+            "hash": hashlib.md5(hw_info_plist).hexdigest(),
+            "data": hw_info_plist,
+        },
+        "reportdata": {
+            "hash": hashlib.md5(report_info_plist).hexdigest(),
+            "data": report_info_plist,
+        },
+    }
 
     reportcommon.process(serial, items)
 
     exit(0)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
This change would implement a [Pre-Commit](https://pre-commit.com) configuration that prevents contributors from committing unless certain basic tests pass. As configured here, the tests include:

- [Black](https://black.readthedocs.io/en/stable/) formatting for Python files
- All PHP files pass `php -l` linting check
- No added files exceed 100KB
- No leftover merge conflicts within files
- UNIX style line endings only

Additional hooks have been included in the config file but remain commented out, because they will require a bit more work to initially implement. These future tests could include:

- Eliminating unnecessary trailing whitespace
- Standardizing file endings
- YAML syntax checking (which would catch issues like the one fixed in #1252)
- Verifying executable shebangs

Many other [pre-commit hooks](https://pre-commit.com/hooks.html) are available, some of which may also be useful and can be added later if the maintainers find them useful.

In order to use pre-commit, each contributor would need to [install pre-commit](https://pre-commit.com/#install), then run `pre-commit install` to activate the hooks. A similar system is now in use for the [AutoPkg project](https://github.com/autopkg/autopkg/blob/master/CONTRIBUTING.md#use-pre-commit-to-set-automatic-commit-requirements).

Thanks for considering!