### PR TITLE
fix one forgotten case of curl quoting in install script

### DIFF
--- a/app/views/install/install_script.php
+++ b/app/views/install/install_script.php
@@ -164,7 +164,7 @@ chmod a+x "${MUNKIPATH}"{${PREFLIGHT_SCRIPT},${POSTFLIGHT_SCRIPT},${REPORT_BROKE
 # Create preflight.d + download scripts
 mkdir -p "${MUNKIPATH}preflight.d"
 cd "${MUNKIPATH}preflight.d"
-${CURL[@]} "${TPL_BASE}submit.preflight" --remote-name
+"${CURL[@]}" "${TPL_BASE}submit.preflight" --remote-name
 
 if [ "${?}" != 0 ]
 then


### PR DESCRIPTION
only materialized itself when additional headers where set: in this case
they where not passed quoted correctly