### PR TITLE
Clarifying Example DB path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@
 # DATABASE
 # --------
 CONNECTION_DRIVER="sqlite"
-CONNECTION_DATABASE="app/db/db.sqlite"
+#CONNECTION_DATABASE="/path/to/your/custom/db/db.sqlite"
 
 #CONNECTION_DRIVER="mysql"
 #CONNECTION_HOST="127.0.0.1"


### PR DESCRIPTION
The default .env.example will not work because of the `CONNECTION_DATABASE` string. Commenting it out by default and entering more clarifying text to guide the user.