### PR TITLE
Fix issue with extra slashes in install script URL

### DIFF
--- a/app/views/install/install_script.php
+++ b/app/views/install/install_script.php
@@ -140,8 +140,14 @@ rm -rf "${MUNKIPATH}postflight.d" && ln -s "scripts" "${MUNKIPATH}postflight.d"
 mkdir -p "${INSTALLROOT}/usr/local/munki"
 mkdir -p "${INSTALLROOT}/Library/LaunchDaemons"
 
+#Normalize BASEURL so it has a trailing slash.
+if [[ ${BASEURL: -1} != "/" ]]
+then
+    BASEURL="${BASEURL}/"
+fi
+
 echo "BaseURL is ${BASEURL}"
-TPL_BASE="${BASEURL}/assets/client_installer/payload/"
+TPL_BASE="${BASEURL}assets/client_installer/payload"
 
 echo "# Retrieving munkireport scripts"
 SCRIPTS=$("${CURL[@]}" "${BASEURL}index.php?/install/get_paths")


### PR DESCRIPTION
This change normalizes the BaseURL provided and adds a trailing slash if one is not present.
Another slash correction is made in the `TPL_BASE` value so there are no double slashes in the URL. Some web servers (like Caddy) do not handle double slashes and fail to download resources.

I've tested this on my apache setup and it works both with and without my changes.