### PR TITLE
Fix php endif

### DIFF
--- a/app/views/client/summary_tab.php
+++ b/app/views/client/summary_tab.php
@@ -7,7 +7,7 @@
 </div><!-- /row -->
 <div class="row">
 
-    <?endif?>
+    <?php endif ?>
         <!-- <?php echo $widget_id ?> -->
         <?php $this->view($data['view'], isset($data['view_vars'])?$data['view_vars']:array(), isset($data['view_path'])?$data['view_path']:conf('view_path'));?>
     


### PR DESCRIPTION
Was getting the following error on this branch when trying to view a client detail summary page:
```Parse error: syntax error, unexpected 'endforeach' (T_ENDFOREACH), expecting elseif (T_ELSEIF) or else (T_ELSE) or endif (T_ENDIF) in /Volumes/ExtHD/munkireport-php/app/views/client/summary_tab.php on line 14```

Changing line 10 to be `<?php endif ?>` instead of `<?endif?>` loads the summary data and customized modules in the web view.