### PR TITLE
Add pre-commit hooks for PHP linting, Python Black, and other basics (conflict resolved)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
   - id: check-case-conflict
   # - id: check-docstring-first
   # - id: check-executables-have-shebangs
+  - id: check-json
   - id: check-merge-conflict
   # - id: check-yaml
   # - id: end-of-file-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
   # - id: check-executables-have-shebangs
   - id: check-json
   - id: check-merge-conflict
+  - id: check-xml
   # - id: check-yaml
   # - id: end-of-file-fixer
   - id: mixed-line-ending

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.2.3
+  hooks:
+  - id: check-added-large-files
+    args: [--maxkb=100]
+  - id: check-ast
+  - id: check-byte-order-marker
+  - id: check-case-conflict
+  # - id: check-docstring-first
+  # - id: check-executables-have-shebangs
+  - id: check-merge-conflict
+  # - id: check-yaml
+  # - id: end-of-file-fixer
+  - id: mixed-line-ending
+  # - id: trailing-whitespace
+  #   args: [--markdown-linebreak-ext=md]
+- repo: https://github.com/digitalpulp/pre-commit-php
+  rev: 1.3.0
+  hooks:
+  - id: php-lint-all
+- repo: https://github.com/python/black
+  rev: 19.3b0
+  hooks:
+  - id: black

--- a/build/mr_upgrade.py
+++ b/build/mr_upgrade.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
-"""
-Script for upgrading MunkiReport.
-"""
+"""Script for upgrading MunkiReport."""
 
 import argparse
 import datetime
@@ -49,7 +47,7 @@ def run_command(args: list, suppress_output: bool = False) -> bool:
 
 
 def get_current_version(install_path: str) -> str:
-    """Return current build version"""
+    """Return current build version."""
     helper = install_path + "app/helpers/site_helper.php"
     if os.path.exists(helper):
         try:
@@ -231,7 +229,7 @@ def backup_files(backup_dir: str, install_path: str, current_time: str) -> bool:
 
 
 def get_versions() -> dict:
-    """Return MR versions"""
+    """Return MR versions."""
     mr_api = "https://api.github.com/repos/munkireport/munkireport-php/releases"
     log.debug(f"Querying '{mr_api}' for latest release...")
     versions = {}

--- a/build/release/make_munkireport_release.py
+++ b/build/release/make_munkireport_release.py
@@ -13,7 +13,7 @@
 # Requires an OAuth token with push access to the repo. Currently the GitHub
 # Releases API is in a 'preview' status, and this script does very little error
 # handling.
-'''See docstring for main() function'''
+"""See docstring for main() function."""
 
 import json
 import optparse
@@ -31,7 +31,7 @@ from shutil import rmtree
 from time import strftime
 
 class GitHubAPIError(BaseException):
-    '''Base error for GitHub API interactions'''
+    """Base error for GitHub API interactions."""
     pass
 
 
@@ -111,17 +111,16 @@ def run_command(cmd):
     subprocess.check_call(cmd)
 
 def main():
-    """Builds and pushes a new munkireport-php release from an existing Git clone
-of munkireport-php.
+    """Builds and pushes a new munkireport-php release from an existing Git
+    clone of munkireport-php.
 
-Requirements:
+    Requirements:
 
-API token:
-You'll need an API OAuth token with push access to the repo. You can create a
-Personal Access Token in your user's Account Settings:
-https://github.com/settings/applications
-
-"""
+    API token:
+    You'll need an API OAuth token with push access to the repo. You can create a
+    Personal Access Token in your user's Account Settings:
+    https://github.com/settings/applications
+    """
     usage = __doc__
     parser = optparse.OptionParser(usage=usage)
     parser.add_option('-t', '--token',

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/FoundationPlist.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/FoundationPlist.py
@@ -55,27 +55,27 @@ from Foundation import NSPropertyListXMLFormat_v1_0
 
 
 class FoundationPlistException(Exception):
-    """Basic exception for plist errors"""
+    """Basic exception for plist errors."""
 
     pass
 
 
 class NSPropertyListSerializationException(FoundationPlistException):
-    """Read/parse error for plists"""
+    """Read/parse error for plists."""
 
     pass
 
 
 class NSPropertyListWriteException(FoundationPlistException):
-    """Write error for plists"""
+    """Write error for plists."""
 
     pass
 
 
 def readPlist(filepath):
-    """
-    Read a .plist file from filepath.  Return the unpacked root object
-    (which is usually a dictionary).
+    """Read a .plist file from filepath.
+
+    Return the unpacked root object (which is usually a dictionary).
     """
     plistData = NSData.dataWithContentsOfFile_(filepath)
     (
@@ -97,7 +97,10 @@ def readPlist(filepath):
 
 
 def readPlistFromString(data):
-    """Read a plist data from a string. Return the root object."""
+    """Read a plist data from a string.
+
+    Return the root object.
+    """
     try:
         plistData = buffer(data)
     except TypeError, err:
@@ -120,9 +123,7 @@ def readPlistFromString(data):
 
 
 def writePlist(dataObject, filepath):
-    """
-    Write 'rootObject' as a plist to filepath.
-    """
+    """Write 'rootObject' as a plist to filepath."""
     (
         plistData,
         error,

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/FoundationPlist.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/FoundationPlist.py
@@ -47,6 +47,7 @@ from Foundation import NSData
 from Foundation import NSPropertyListSerialization
 from Foundation import NSPropertyListMutableContainers
 from Foundation import NSPropertyListXMLFormat_v1_0
+
 # pylint: enable=E0611
 
 # Disable PyLint complaining about 'invalid' camelCase names
@@ -55,15 +56,21 @@ from Foundation import NSPropertyListXMLFormat_v1_0
 
 class FoundationPlistException(Exception):
     """Basic exception for plist errors"""
+
     pass
+
 
 class NSPropertyListSerializationException(FoundationPlistException):
     """Read/parse error for plists"""
+
     pass
+
 
 class NSPropertyListWriteException(FoundationPlistException):
     """Write error for plists"""
+
     pass
+
 
 def readPlist(filepath):
     """
@@ -71,13 +78,16 @@ def readPlist(filepath):
     (which is usually a dictionary).
     """
     plistData = NSData.dataWithContentsOfFile_(filepath)
-    dataObject, dummy_plistFormat, error = (
-        NSPropertyListSerialization.
-        propertyListFromData_mutabilityOption_format_errorDescription_(
-            plistData, NSPropertyListMutableContainers, None, None))
+    (
+        dataObject,
+        dummy_plistFormat,
+        error,
+    ) = NSPropertyListSerialization.propertyListFromData_mutabilityOption_format_errorDescription_(
+        plistData, NSPropertyListMutableContainers, None, None
+    )
     if dataObject is None:
         if error:
-            error = error.encode('ascii', 'ignore')
+            error = error.encode("ascii", "ignore")
         else:
             error = "Unknown error"
         errmsg = "%s in file %s" % (error, filepath)
@@ -87,18 +97,21 @@ def readPlist(filepath):
 
 
 def readPlistFromString(data):
-    '''Read a plist data from a string. Return the root object.'''
+    """Read a plist data from a string. Return the root object."""
     try:
         plistData = buffer(data)
     except TypeError, err:
         raise NSPropertyListSerializationException(err)
-    dataObject, dummy_plistFormat, error = (
-        NSPropertyListSerialization.
-        propertyListFromData_mutabilityOption_format_errorDescription_(
-            plistData, NSPropertyListMutableContainers, None, None))
+    (
+        dataObject,
+        dummy_plistFormat,
+        error,
+    ) = NSPropertyListSerialization.propertyListFromData_mutabilityOption_format_errorDescription_(
+        plistData, NSPropertyListMutableContainers, None, None
+    )
     if dataObject is None:
         if error:
-            error = error.encode('ascii', 'ignore')
+            error = error.encode("ascii", "ignore")
         else:
             error = "Unknown error"
         raise NSPropertyListSerializationException(error)
@@ -107,16 +120,18 @@ def readPlistFromString(data):
 
 
 def writePlist(dataObject, filepath):
-    '''
+    """
     Write 'rootObject' as a plist to filepath.
-    '''
-    plistData, error = (
-        NSPropertyListSerialization.
-        dataFromPropertyList_format_errorDescription_(
-            dataObject, NSPropertyListXMLFormat_v1_0, None))
+    """
+    (
+        plistData,
+        error,
+    ) = NSPropertyListSerialization.dataFromPropertyList_format_errorDescription_(
+        dataObject, NSPropertyListXMLFormat_v1_0, None
+    )
     if plistData is None:
         if error:
-            error = error.encode('ascii', 'ignore')
+            error = error.encode("ascii", "ignore")
         else:
             error = "Unknown error"
         raise NSPropertyListSerializationException(error)
@@ -125,18 +140,21 @@ def writePlist(dataObject, filepath):
             return
         else:
             raise NSPropertyListWriteException(
-                "Failed to write plist data to %s" % filepath)
+                "Failed to write plist data to %s" % filepath
+            )
 
 
 def writePlistToString(rootObject):
-    '''Return 'rootObject' as a plist-formatted string.'''
-    plistData, error = (
-        NSPropertyListSerialization.
-        dataFromPropertyList_format_errorDescription_(
-            rootObject, NSPropertyListXMLFormat_v1_0, None))
+    """Return 'rootObject' as a plist-formatted string."""
+    (
+        plistData,
+        error,
+    ) = NSPropertyListSerialization.dataFromPropertyList_format_errorDescription_(
+        rootObject, NSPropertyListXMLFormat_v1_0, None
+    )
     if plistData is None:
         if error:
-            error = error.encode('ascii', 'ignore')
+            error = error.encode("ascii", "ignore")
         else:
             error = "Unknown error"
         raise NSPropertyListSerializationException(error)
@@ -144,5 +162,5 @@ def writePlistToString(rootObject):
         return str(plistData)
 
 
-if __name__ == '__main__':
-    print 'This is a library of support tools for the Munki Suite.'
+if __name__ == "__main__":
+    print "This is a library of support tools for the Munki Suite."

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/constants.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/constants.py
@@ -13,8 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-constants.py
+"""constants.py.
 
 Created by Greg Neagle on 2016-12-14.
 

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/constants.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/constants.py
@@ -33,15 +33,16 @@ EXIT_STATUS_SERVER_UNAVAILABLE = 150
 EXIT_STATUS_INVALID_PARAMETERS = 200
 EXIT_STATUS_ROOT_REQUIRED = 201
 
-BUNDLE_ID = 'MunkiReport'
+BUNDLE_ID = "MunkiReport"
 # the following two items are not used internally by Munki
 # any longer, but remain for backwards compatibility with
 # pre and postflight script that might access these files directly
-MANAGED_INSTALLS_PLIST_PATH = '/Library/Preferences/' + BUNDLE_ID + '.plist'
-SECURE_MANAGED_INSTALLS_PLIST_PATH = \
-    '/private/var/root/Library/Preferences/' + BUNDLE_ID + '.plist'
+MANAGED_INSTALLS_PLIST_PATH = "/Library/Preferences/" + BUNDLE_ID + ".plist"
+SECURE_MANAGED_INSTALLS_PLIST_PATH = (
+    "/private/var/root/Library/Preferences/" + BUNDLE_ID + ".plist"
+)
 
-ADDITIONAL_HTTP_HEADERS_KEY = 'AdditionalHttpHeaders'
+ADDITIONAL_HTTP_HEADERS_KEY = "AdditionalHttpHeaders"
 
-if __name__ == '__main__':
-    print 'This is a library of support tools for the Munki Suite.'
+if __name__ == "__main__":
+    print "This is a library of support tools for the Munki Suite."

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/display.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/display.py
@@ -13,8 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-display.py
+"""display.py.
 
 Created by Greg Neagle on 2016-12-13.
 
@@ -30,9 +29,7 @@ from . import reports
 
 
 def _getsteps(num_of_steps, limit):
-    """
-    Helper function for display_percent_done
-    """
+    """Helper function for display_percent_done."""
     steps = []
     current = 0.0
     for i in range(0, num_of_steps):
@@ -59,7 +56,7 @@ def str_to_ascii(a_string):
 
 
 def _to_unicode(obj, encoding="UTF-8"):
-    """Coerces basestring obj to unicode"""
+    """Coerces basestring obj to unicode."""
     if isinstance(obj, basestring):
         if not isinstance(obj, unicode):
             obj = unicode(obj, encoding)
@@ -67,8 +64,8 @@ def _to_unicode(obj, encoding="UTF-8"):
 
 
 def _concat_message(msg, *args):
-    """Concatenates a string with any additional arguments,
-    making sure everything is unicode"""
+    """Concatenates a string with any additional arguments, making sure
+    everything is unicode."""
     # coerce msg to unicode if it's not already
     msg = _to_unicode(msg)
     if args:
@@ -84,9 +81,7 @@ def _concat_message(msg, *args):
 
 
 def display_info(msg, *args):
-    """
-    Displays info messages.
-    """
+    """Displays info messages."""
     msg = _concat_message(msg, *args)
     munkilog.log(u"    " + msg)
     if verbose > 0:
@@ -95,10 +90,10 @@ def display_info(msg, *args):
 
 
 def display_detail(msg, *args):
-    """
-    Displays minor info messages.
-    These are usually logged only, but can be printed to
-    stdout if verbose is set greater than 1
+    """Displays minor info messages.
+
+    These are usually logged only, but can be printed to stdout if
+    verbose is set greater than 1
     """
     msg = _concat_message(msg, *args)
     if verbose > 1:
@@ -109,9 +104,7 @@ def display_detail(msg, *args):
 
 
 def display_debug1(msg, *args):
-    """
-    Displays debug messages, formatting as needed.
-    """
+    """Displays debug messages, formatting as needed."""
     msg = _concat_message(msg, *args)
     if verbose > 2:
         print "    %s" % msg.encode("UTF-8")
@@ -121,9 +114,7 @@ def display_debug1(msg, *args):
 
 
 def display_debug2(msg, *args):
-    """
-    Displays debug messages, formatting as needed.
-    """
+    """Displays debug messages, formatting as needed."""
     msg = _concat_message(msg, *args)
     if verbose > 3:
         print "    %s" % msg.encode("UTF-8")
@@ -132,9 +123,7 @@ def display_debug2(msg, *args):
 
 
 def display_warning(msg, *args):
-    """
-    Prints warning msgs to stderr and the log
-    """
+    """Prints warning msgs to stderr and the log."""
     msg = _concat_message(msg, *args)
     warning = "WARNING: %s" % msg
     if verbose > 0:
@@ -149,9 +138,7 @@ def display_warning(msg, *args):
 
 
 def display_error(msg, *args):
-    """
-    Prints msg to stderr and the log
-    """
+    """Prints msg to stderr and the log."""
     msg = _concat_message(msg, *args)
     errmsg = "ERROR: %s" % msg
     if verbose > 0:

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/display.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/display.py
@@ -29,7 +29,6 @@ from . import prefs
 from . import reports
 
 
-
 def _getsteps(num_of_steps, limit):
     """
     Helper function for display_percent_done
@@ -37,11 +36,11 @@ def _getsteps(num_of_steps, limit):
     steps = []
     current = 0.0
     for i in range(0, num_of_steps):
-        if i == num_of_steps-1:
+        if i == num_of_steps - 1:
             steps.append(int(round(limit)))
         else:
             steps.append(int(round(current)))
-        current += float(limit)/float(num_of_steps-1)
+        current += float(limit) / float(num_of_steps - 1)
     return steps
 
 
@@ -54,12 +53,12 @@ def str_to_ascii(a_string):
       str, ascii form, no >7bit chars
     """
     try:
-        return unicode(a_string).encode('ascii', 'ignore')
+        return unicode(a_string).encode("ascii", "ignore")
     except UnicodeDecodeError:
-        return a_string.decode('ascii', 'ignore')
+        return a_string.decode("ascii", "ignore")
 
 
-def _to_unicode(obj, encoding='UTF-8'):
+def _to_unicode(obj, encoding="UTF-8"):
     """Coerces basestring obj to unicode"""
     if isinstance(obj, basestring):
         if not isinstance(obj, unicode):
@@ -79,8 +78,8 @@ def _concat_message(msg, *args):
             msg = msg % tuple(args)
         except TypeError, dummy_err:
             warnings.warn(
-                'String format does not match concat args: %s'
-                % (str(sys.exc_info())))
+                "String format does not match concat args: %s" % (str(sys.exc_info()))
+            )
     return msg.rstrip()
 
 
@@ -89,9 +88,9 @@ def display_info(msg, *args):
     Displays info messages.
     """
     msg = _concat_message(msg, *args)
-    munkilog.log(u'    ' + msg)
+    munkilog.log(u"    " + msg)
     if verbose > 0:
-        print '    %s' % msg.encode('UTF-8')
+        print "    %s" % msg.encode("UTF-8")
         sys.stdout.flush()
 
 
@@ -103,10 +102,10 @@ def display_detail(msg, *args):
     """
     msg = _concat_message(msg, *args)
     if verbose > 1:
-        print '    %s' % msg.encode('UTF-8')
+        print "    %s" % msg.encode("UTF-8")
         sys.stdout.flush()
-    if prefs.pref('LoggingLevel') > 0:
-        munkilog.log(u'    ' + msg)
+    if prefs.pref("LoggingLevel") > 0:
+        munkilog.log(u"    " + msg)
 
 
 def display_debug1(msg, *args):
@@ -115,10 +114,10 @@ def display_debug1(msg, *args):
     """
     msg = _concat_message(msg, *args)
     if verbose > 2:
-        print '    %s' % msg.encode('UTF-8')
+        print "    %s" % msg.encode("UTF-8")
         sys.stdout.flush()
-    if prefs.pref('LoggingLevel') > 1:
-        munkilog.log('DEBUG1: %s' % msg)
+    if prefs.pref("LoggingLevel") > 1:
+        munkilog.log("DEBUG1: %s" % msg)
 
 
 def display_debug2(msg, *args):
@@ -127,9 +126,9 @@ def display_debug2(msg, *args):
     """
     msg = _concat_message(msg, *args)
     if verbose > 3:
-        print '    %s' % msg.encode('UTF-8')
-    if prefs.pref('LoggingLevel') > 2:
-        munkilog.log('DEBUG2: %s' % msg)
+        print "    %s" % msg.encode("UTF-8")
+    if prefs.pref("LoggingLevel") > 2:
+        munkilog.log("DEBUG2: %s" % msg)
 
 
 def display_warning(msg, *args):
@@ -137,16 +136,16 @@ def display_warning(msg, *args):
     Prints warning msgs to stderr and the log
     """
     msg = _concat_message(msg, *args)
-    warning = 'WARNING: %s' % msg
+    warning = "WARNING: %s" % msg
     if verbose > 0:
-        print >> sys.stderr, warning.encode('UTF-8')
+        print >> sys.stderr, warning.encode("UTF-8")
     munkilog.log(warning)
     # append this warning to our warnings log
-    munkilog.log(warning, 'warnings.log')
+    munkilog.log(warning, "warnings.log")
     # collect the warning for later reporting
-    if 'Warnings' not in reports.report:
-        reports.report['Warnings'] = []
-    reports.report['Warnings'].append('%s' % msg)
+    if "Warnings" not in reports.report:
+        reports.report["Warnings"] = []
+    reports.report["Warnings"].append("%s" % msg)
 
 
 def display_error(msg, *args):
@@ -154,16 +153,16 @@ def display_error(msg, *args):
     Prints msg to stderr and the log
     """
     msg = _concat_message(msg, *args)
-    errmsg = 'ERROR: %s' % msg
+    errmsg = "ERROR: %s" % msg
     if verbose > 0:
-        print >> sys.stderr, errmsg.encode('UTF-8')
+        print >> sys.stderr, errmsg.encode("UTF-8")
     munkilog.log(errmsg)
     # append this error to our errors log
-    munkilog.log(errmsg, 'errors.log')
+    munkilog.log(errmsg, "errors.log")
     # collect the errors for later reporting
-    if 'Errors' not in reports.report:
-        reports.report['Errors'] = []
-    reports.report['Errors'].append('%s' % msg)
+    if "Errors" not in reports.report:
+        reports.report["Errors"] = []
+    reports.report["Errors"].append("%s" % msg)
 
 
 # module globals
@@ -172,5 +171,5 @@ verbose = 1
 # pylint: enable=invalid-name
 
 
-if __name__ == '__main__':
-    print 'This is a library of support tools for the Munki Suite.'
+if __name__ == "__main__":
+    print "This is a library of support tools for the Munki Suite."

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/munkilog.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/munkilog.py
@@ -30,7 +30,7 @@ import time
 from . import prefs
 
 
-def log(msg, logname=''):
+def log(msg, logname=""):
     """Generic logging function."""
     if len(msg) > 1000:
         # See http://bugs.python.org/issue11907 and RFC-3164
@@ -43,16 +43,16 @@ def log(msg, logname=''):
         logging.info(msg)  # noop unless configure_syslog() is called first.
 
     # date/time format string
-    formatstr = '%b %d %Y %H:%M:%S %z'
+    formatstr = "%b %d %Y %H:%M:%S %z"
     if not logname:
         # use our regular logfile
-        logpath = prefs.pref('LogFile')
+        logpath = prefs.pref("LogFile")
     else:
-        logpath = os.path.join(os.path.dirname(prefs.pref('LogFile')), logname)
+        logpath = os.path.join(os.path.dirname(prefs.pref("LogFile")), logname)
     try:
-        fileobj = open(logpath, mode='a', buffering=1)
+        fileobj = open(logpath, mode="a", buffering=1)
         try:
-            print >> fileobj, time.strftime(formatstr), msg.encode('UTF-8')
+            print >> fileobj, time.strftime(formatstr), msg.encode("UTF-8")
         except (OSError, IOError):
             pass
         fileobj.close()
@@ -72,46 +72,46 @@ def configure_syslog():
     # then /var/run/syslog stops listening.  If we fail to catch this then
     # Munki completely errors.
     try:
-        syslog = logging.handlers.SysLogHandler('/var/run/syslog')
+        syslog = logging.handlers.SysLogHandler("/var/run/syslog")
     except BaseException:
-        log('LogToSyslog is enabled but socket connection failed.')
+        log("LogToSyslog is enabled but socket connection failed.")
         return
 
-    syslog.setFormatter(logging.Formatter('munkireport: %(message)s'))
+    syslog.setFormatter(logging.Formatter("munkireport: %(message)s"))
     syslog.setLevel(logging.INFO)
     logger.addHandler(syslog)
 
 
-def rotatelog(logname=''):
+def rotatelog(logname=""):
     """Rotate a log"""
     if not logname:
         # use our regular logfile
-        logpath = prefs.pref('LogFile')
+        logpath = prefs.pref("LogFile")
     else:
-        logpath = os.path.join(os.path.dirname(prefs.pref('LogFile')), logname)
+        logpath = os.path.join(os.path.dirname(prefs.pref("LogFile")), logname)
     if os.path.exists(logpath):
         for i in range(3, -1, -1):
             try:
-                os.unlink(logpath + '.' + str(i + 1))
+                os.unlink(logpath + "." + str(i + 1))
             except (OSError, IOError):
                 pass
             try:
-                os.rename(logpath + '.' + str(i), logpath + '.' + str(i + 1))
+                os.rename(logpath + "." + str(i), logpath + "." + str(i + 1))
             except (OSError, IOError):
                 pass
         try:
-            os.rename(logpath, logpath + '.0')
+            os.rename(logpath, logpath + ".0")
         except (OSError, IOError):
             pass
 
 
 def rotate_main_log():
     """Rotate our main log"""
-    main_log = prefs.pref('LogFile')
+    main_log = prefs.pref("LogFile")
     if os.path.exists(main_log):
         if os.path.getsize(main_log) > 1000000:
             rotatelog(main_log)
 
 
-if __name__ == '__main__':
-    print 'This is a library of support tools for the Munki Suite.'
+if __name__ == "__main__":
+    print "This is a library of support tools for the Munki Suite."

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/munkilog.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/munkilog.py
@@ -13,8 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-munkilog.py
+"""munkilog.py.
 
 Created by Greg Neagle on 2016-12-14.
 
@@ -83,7 +82,7 @@ def configure_syslog():
 
 
 def rotatelog(logname=""):
-    """Rotate a log"""
+    """Rotate a log."""
     if not logname:
         # use our regular logfile
         logpath = prefs.pref("LogFile")
@@ -106,7 +105,7 @@ def rotatelog(logname=""):
 
 
 def rotate_main_log():
-    """Rotate our main log"""
+    """Rotate our main log."""
     main_log = prefs.pref("LogFile")
     if os.path.exists(main_log):
         if os.path.getsize(main_log) > 1000000:

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/phpserialize.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/phpserialize.py
@@ -13,16 +13,20 @@ from decimal import Decimal
 import string
 import objc
 
+
 class PhpSerializationError(ValueError):
     pass
 
+
 class PhpUnserializationError(ValueError):
     pass
+
 
 class _PhpUnserializationError(ValueError):
     def __init__(self, msg, rest):
         self.message = msg
         self.rest = rest
+
 
 class PHP_Class(object):
     def __init__(self, name, properties=()):
@@ -54,14 +58,15 @@ class PHP_Class(object):
 
 
 class PHP_Property(object):
-    SEPARATOR = '\x00'
+    SEPARATOR = "\x00"
+
     def __init__(self, php_name, value):
         self.php_name = php_name
         self.name = php_name.split(self.SEPARATOR)[-1]
         self.value = value
 
     def __repr__(self):
-        return 'PHP_Property(%s, %s)' % (repr(self.php_name), repr(self.value))
+        return "PHP_Property(%s, %s)" % (repr(self.php_name), repr(self.value))
 
     __str__ = __unicode__ = __repr__
 
@@ -71,7 +76,7 @@ def print_php_class(cls, lvl=0):
         raise ValueError(type(cls))
 
     def _print(s, l=None):
-        print string.ljust('', l or lvl, '\t') + s
+        print string.ljust("", l or lvl, "\t") + s
 
     def print_list(lst):
         for item in lst:
@@ -86,19 +91,19 @@ def print_php_class(cls, lvl=0):
 
     def print_property(prt):
         if isinstance(prt.value, PHP_Class):
-            _print('property ' + prt.name + ':')
+            _print("property " + prt.name + ":")
             print_php_class(prt.value, lvl + 1)
         elif isinstance(prt.value, list):
             if len(prt.value):
-                _print('property ' + prt.name + ': [')
+                _print("property " + prt.name + ": [")
                 print_list(prt.value)
-                _print(']')
+                _print("]")
             else:
-                _print('property ' + prt.name + ': []')
+                _print("property " + prt.name + ": []")
         else:
-            _print('property ' + prt.name + ': ' + repr(prt.value))
+            _print("property " + prt.name + ": " + repr(prt.value))
 
-    _print('class ' + cls.name)
+    _print("class " + cls.name)
     lvl += 1
     for prt in cls:
         print_property(prt)
@@ -108,8 +113,8 @@ def unserialize(s):
     """
     Unserialize python struct from php serialization format
     """
-    if not isinstance(s, basestring) or s == '':
-        raise ValueError('Unserialize argument must be non-empty string')
+    if not isinstance(s, basestring) or s == "":
+        raise ValueError("Unserialize argument must be non-empty string")
 
     try:
         return Unserializator(s).unserialize()
@@ -117,12 +122,12 @@ def unserialize(s):
         char = len(str(s)) - len(e.rest)
         delta = 50
         try:
-            sample = u'...%s --> %s <-- %s...' % (
-                s[(char > delta and char - delta or 0):char],
+            sample = u"...%s --> %s <-- %s..." % (
+                s[(char > delta and char - delta or 0) : char],
                 s[char],
-                s[char + 1:char + delta]
+                s[char + 1 : char + delta],
             )
-            message = u'%s in %s' % (e.message, sample)
+            message = u"%s in %s" % (e.message, sample)
         except Exception, e:
             raise
         raise PhpUnserializationError(message)
@@ -137,36 +142,38 @@ def serialize(struct, typecast=None):
 
     # N;
     if struct is None:
-        return 'N;'
+        return "N;"
 
     struct_type = type(struct)
     # d:<float>;
     if struct_type is float:
-        return 'd:%.20f;' % struct  # 20 digits after comma
+        return "d:%.20f;" % struct  # 20 digits after comma
 
     # d:<float>;
     if struct_type is Decimal:
-        return 'd:%.20f;' % struct  # 20 digits after comma
+        return "d:%.20f;" % struct  # 20 digits after comma
 
     # b:<0 or 1>;
     if struct_type is bool:
-        return 'b:%d;' % int(struct)
+        return "b:%d;" % int(struct)
 
     # i:<integer>;
     if struct_type is int or struct_type is long:
-        return 'i:%d;' % struct
+        return "i:%d;" % struct
 
     # s:<string_length>:"<string>";
     if struct_type is str:
         return 's:%d:"%s";' % (len(struct), struct)
 
     if struct_type is unicode:
-        return serialize(struct.encode('utf-8'), typecast)
+        return serialize(struct.encode("utf-8"), typecast)
 
     # a:<hash_length>:{<key><value><key2><value2>...<keyN><valueN>}
     if struct_type is dict:
-        core = ''.join([serialize(k, typecast) + serialize(v, typecast) for k, v in struct.items()])
-        return 'a:%d:{%s}' % (len(struct), core)
+        core = "".join(
+            [serialize(k, typecast) + serialize(v, typecast) for k, v in struct.items()]
+        )
+        return "a:%d:{%s}" % (len(struct), core)
 
     if struct_type is tuple or struct_type is list:
         return serialize(dict(enumerate(struct)), typecast)
@@ -176,13 +183,18 @@ def serialize(struct, typecast=None):
             len(struct.name),
             struct.name,
             len(struct),
-            ''.join([serialize(x.php_name, typecast) + serialize(x.value, typecast) for x in struct]),
+            "".join(
+                [
+                    serialize(x.php_name, typecast) + serialize(x.value, typecast)
+                    for x in struct
+                ]
+            ),
         )
 
     if struct_type is objc.pyobjc_unicode:
-        return serialize(struct.encode('utf-8'), typecast)
+        return serialize(struct.encode("utf-8"), typecast)
 
-    raise PhpSerializationError('PHP serialize: cannot encode %r' % struct)
+    raise PhpSerializationError("PHP serialize: cannot encode %r" % struct)
 
 
 class Unserializator(object):
@@ -191,14 +203,16 @@ class Unserializator(object):
         self._str = s
 
     def await(self, symbol, n=1):
-        #result = self.take(len(symbol))
-        result = self._str[self._position:self._position + n]
+        # result = self.take(len(symbol))
+        result = self._str[self._position : self._position + n]
         self._position += n
         if result != symbol:
-            raise _PhpUnserializationError('Next is `%s` not `%s`' % (result, symbol), self.get_rest())
+            raise _PhpUnserializationError(
+                "Next is `%s` not `%s`" % (result, symbol), self.get_rest()
+            )
 
     def take(self, n=1):
-        result = self._str[self._position:self._position + n]
+        result = self._str[self._position : self._position + n]
         self._position += n
         return result
 
@@ -206,8 +220,8 @@ class Unserializator(object):
         try:
             stopsymbol_position = self._str.index(stopsymbol, self._position)
         except ValueError:
-            raise _PhpUnserializationError('No `%s`' % stopsymbol, self.get_rest())
-        result = self._str[self._position:stopsymbol_position]
+            raise _PhpUnserializationError("No `%s`" % stopsymbol, self.get_rest())
+        result = self._str[self._position : stopsymbol_position]
         self._position = stopsymbol_position + 1
         if typecast is None:
             return result
@@ -215,43 +229,43 @@ class Unserializator(object):
             return typecast(result)
 
     def get_rest(self):
-        return self._str[self._position:]
+        return self._str[self._position :]
 
     def unserialize(self):
         t = self.take()
 
-        if t == 'N':
-            self.await(';')
+        if t == "N":
+            self.await(";")
             return None
 
-        self.await(':')
+        self.await(":")
 
-        if t == 'i':
-            return self.take_while_not(';', int)
+        if t == "i":
+            return self.take_while_not(";", int)
 
-        if t == 'd':
-            return self.take_while_not(';', float)
+        if t == "d":
+            return self.take_while_not(";", float)
 
-        if t == 'b':
-            return bool(self.take_while_not(';', int))
+        if t == "b":
+            return bool(self.take_while_not(";", int))
 
-        if t == 's':
-            size = self.take_while_not(':', int)
+        if t == "s":
+            size = self.take_while_not(":", int)
             self.await('"')
             result = self.take(size)
             self.await('";', 2)
             return result
 
-        if t == 'a':
-            size = self.take_while_not(':', int)
+        if t == "a":
+            size = self.take_while_not(":", int)
             return self.parse_hash_core(size)
 
-        if t == 'O':
-            object_name_size = self.take_while_not(':', int)
+        if t == "O":
+            object_name_size = self.take_while_not(":", int)
             self.await('"')
             object_name = self.take(object_name_size)
             self.await('":', 2)
-            object_length = self.take_while_not(':', int)
+            object_length = self.take_while_not(":", int)
             php_class = PHP_Class(object_name)
             members = self.parse_hash_core(object_length)
             if members:
@@ -259,11 +273,11 @@ class Unserializator(object):
                     php_class.set_item(php_name, value)
             return php_class
 
-        raise _PhpUnserializationError('Unknown type `%s`' % t, self.get_rest())
+        raise _PhpUnserializationError("Unknown type `%s`" % t, self.get_rest())
 
     def parse_hash_core(self, size):
         result = {}
-        self.await('{')
+        self.await("{")
         is_array = True
         for i in range(size):
             k = self.unserialize()
@@ -273,5 +287,5 @@ class Unserializator(object):
                 is_array = False
         if is_array:
             result = result.values()
-        self.await('}')
+        self.await("}")
         return result

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/phpserialize.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/phpserialize.py
@@ -110,9 +110,7 @@ def print_php_class(cls, lvl=0):
 
 
 def unserialize(s):
-    """
-    Unserialize python struct from php serialization format
-    """
+    """Unserialize python struct from php serialization format."""
     if not isinstance(s, basestring) or s == "":
         raise ValueError("Unserialize argument must be non-empty string")
 
@@ -134,9 +132,7 @@ def unserialize(s):
 
 
 def serialize(struct, typecast=None):
-    """
-    Serialize python struct into php serialization format
-    """
+    """Serialize python struct into php serialization format."""
     if typecast:
         struct = typecast(struct)
 

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/prefs.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/prefs.py
@@ -34,6 +34,7 @@ from Foundation import kCFPreferencesAnyUser
 from Foundation import kCFPreferencesAnyHost
 from Foundation import kCFPreferencesCurrentUser
 from Foundation import kCFPreferencesCurrentHost
+
 # pylint: enable=E0611
 
 from .constants import BUNDLE_ID
@@ -43,15 +44,15 @@ from .constants import BUNDLE_ID
 #####################################################
 
 DEFAULT_PREFS = {
-    'AdditionalHttpHeaders': None,
-    'ClientCertificatePath': None,
-    'FollowHTTPRedirects': 'none',
-    'IgnoreSystemProxies': False,
-    'LogFile': '/Library/MunkiReport/Logs/MunkiReport.log',
-    'LoggingLevel': 1,
-    'LogToSyslog': False,
-    'UseClientCertificate': False,
-    'UseClientCertificateCNAsClientIdentifier': False,
+    "AdditionalHttpHeaders": None,
+    "ClientCertificatePath": None,
+    "FollowHTTPRedirects": "none",
+    "IgnoreSystemProxies": False,
+    "LogFile": "/Library/MunkiReport/Logs/MunkiReport.log",
+    "LoggingLevel": 1,
+    "LogToSyslog": False,
+    "UseClientCertificate": False,
+    "UseClientCertificateCNAsClientIdentifier": False,
 }
 
 
@@ -64,7 +65,7 @@ class Preferences(object):
         Args:
             bundle_id: str, like 'MunkiReport'
         """
-        if bundle_id.endswith('.plist'):
+        if bundle_id.endswith(".plist"):
             bundle_id = bundle_id[:-6]
         self.bundle_id = bundle_id
         self.user = user
@@ -74,7 +75,8 @@ class Preferences(object):
         will fail to iterate all available keys for the preferences domain
         since OS X reads from multiple 'levels' and composites them."""
         keys = CFPreferencesCopyKeyList(
-            self.bundle_id, self.user, kCFPreferencesCurrentHost)
+            self.bundle_id, self.user, kCFPreferencesCurrentHost
+        )
         if keys is not None:
             for i in keys:
                 yield i
@@ -94,8 +96,8 @@ class Preferences(object):
         preference actually gets written at the 'ByHost' level due to the use
         of kCFPreferencesCurrentHost"""
         CFPreferencesSetValue(
-            pref_name, pref_value, self.bundle_id, self.user,
-            kCFPreferencesCurrentHost)
+            pref_name, pref_value, self.bundle_id, self.user, kCFPreferencesCurrentHost
+        )
         CFPreferencesAppSynchronize(self.bundle_id)
 
     def __delitem__(self, pref_name):
@@ -104,7 +106,7 @@ class Preferences(object):
 
     def __repr__(self):
         """Return a text representation of the class"""
-        return '<%s %s>' % (self.__class__.__name__, self.bundle_id)
+        return "<%s %s>" % (self.__class__.__name__, self.bundle_id)
 
     def get(self, pref_name, default=None):
         """Return a preference or the default value"""
@@ -130,8 +132,12 @@ def set_pref(pref_name, pref_value):
     elsewhere (by MCX, for example)"""
     try:
         CFPreferencesSetValue(
-            pref_name, pref_value, BUNDLE_ID,
-            kCFPreferencesAnyUser, kCFPreferencesCurrentHost)
+            pref_name,
+            pref_value,
+            BUNDLE_ID,
+            kCFPreferencesAnyUser,
+            kCFPreferencesCurrentHost,
+        )
         CFPreferencesAppSynchronize(BUNDLE_ID)
     except BaseException:
         pass
@@ -161,5 +167,5 @@ def pref(pref_name):
     return pref_value
 
 
-if __name__ == '__main__':
-    print 'This is a library of support tools for the Munki Suite.'
+if __name__ == "__main__":
+    print "This is a library of support tools for the Munki Suite."

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/prefs.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/prefs.py
@@ -13,8 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-prefs.py
+"""prefs.py.
 
 Created by Greg Neagle on 2016-12-13.
 
@@ -71,9 +70,9 @@ class Preferences(object):
         self.user = user
 
     def __iter__(self):
-        """Iterator for keys in the specific 'level' of preferences; this
-        will fail to iterate all available keys for the preferences domain
-        since OS X reads from multiple 'levels' and composites them."""
+        """Iterator for keys in the specific 'level' of preferences; this will
+        fail to iterate all available keys for the preferences domain since OS
+        X reads from multiple 'levels' and composites them."""
         keys = CFPreferencesCopyKeyList(
             self.bundle_id, self.user, kCFPreferencesCurrentHost
         )
@@ -83,33 +82,39 @@ class Preferences(object):
 
     def __contains__(self, pref_name):
         """Since this uses CFPreferencesCopyAppValue, it will find a preference
-        regardless of the 'level' at which it is stored"""
+        regardless of the 'level' at which it is stored."""
         pref_value = CFPreferencesCopyAppValue(pref_name, self.bundle_id)
         return pref_value is not None
 
     def __getitem__(self, pref_name):
-        """Get a preference value. Normal OS X preference search path applies"""
+        """Get a preference value.
+
+        Normal OS X preference search path applies
+        """
         return CFPreferencesCopyAppValue(pref_name, self.bundle_id)
 
     def __setitem__(self, pref_name, pref_value):
-        """Sets a preference. if the user is kCFPreferencesCurrentUser, the
-        preference actually gets written at the 'ByHost' level due to the use
-        of kCFPreferencesCurrentHost"""
+        """Sets a preference.
+
+        if the user is kCFPreferencesCurrentUser, the preference
+        actually gets written at the 'ByHost' level due to the use of
+        kCFPreferencesCurrentHost
+        """
         CFPreferencesSetValue(
             pref_name, pref_value, self.bundle_id, self.user, kCFPreferencesCurrentHost
         )
         CFPreferencesAppSynchronize(self.bundle_id)
 
     def __delitem__(self, pref_name):
-        """Delete a preference"""
+        """Delete a preference."""
         self.__setitem__(pref_name, None)
 
     def __repr__(self):
-        """Return a text representation of the class"""
+        """Return a text representation of the class."""
         return "<%s %s>" % (self.__class__.__name__, self.bundle_id)
 
     def get(self, pref_name, default=None):
-        """Return a preference or the default value"""
+        """Return a preference or the default value."""
         if not pref_name in self:
             return default
         else:
@@ -117,19 +122,23 @@ class Preferences(object):
 
 
 def reload_prefs():
-    """Uses CFPreferencesAppSynchronize(BUNDLE_ID)
-    to make sure we have the latest prefs. Call this
-    if you have modified /Library/Preferences/MunkiReport.plist
-    or /var/root/Library/Preferences/MunkiReport.plist directly"""
+    """Uses CFPreferencesAppSynchronize(BUNDLE_ID) to make sure we have the
+    latest prefs.
+
+    Call this if you have modified
+    /Library/Preferences/MunkiReport.plist or
+    /var/root/Library/Preferences/MunkiReport.plist directly
+    """
     CFPreferencesAppSynchronize(BUNDLE_ID)
 
 
 def set_pref(pref_name, pref_value):
-    """Sets a preference, writing it to
-    /Library/Preferences/MunkiReport.plist.
-    This should normally be used only for 'bookkeeping' values;
-    values that control the behavior of munki may be overridden
-    elsewhere (by MCX, for example)"""
+    """Sets a preference, writing it to.
+
+    /Library/Preferences/MunkiReport.plist. This should normally be used
+    only for 'bookkeeping' values; values that control the behavior of
+    munki may be overridden elsewhere (by MCX, for example)
+    """
     try:
         CFPreferencesSetValue(
             pref_name,
@@ -146,12 +155,13 @@ def set_pref(pref_name, pref_value):
 def pref(pref_name):
     """Return a preference. Since this uses CFPreferencesCopyAppValue,
     Preferences can be defined several places. Precedence is:
-        - MCX/configuration profile
-        - /var/root/Library/Preferences/ByHost/MunkiReport.XXXXXX.plist
-        - /var/root/Library/Preferences/MunkiReport.plist
-        - /Library/Preferences/MunkiReport.plist
-        - .GlobalPreferences defined at various levels (ByHost, user, system)
-        - default_prefs defined here.
+
+    - MCX/configuration profile
+    - /var/root/Library/Preferences/ByHost/MunkiReport.XXXXXX.plist
+    - /var/root/Library/Preferences/MunkiReport.plist
+    - /Library/Preferences/MunkiReport.plist
+    - .GlobalPreferences defined at various levels (ByHost, user, system)
+    - default_prefs defined here.
     """
     pref_value = CFPreferencesCopyAppValue(pref_name, BUNDLE_ID)
     if pref_value is None:

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/purl.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/purl.py
@@ -40,6 +40,7 @@ from Foundation import NSURLRequestReloadIgnoringLocalCacheData
 from Foundation import NSLog
 from Foundation import NSURLCredential, NSURLCredentialPersistenceNone
 from Foundation import NSData, NSString
+
 # pylint: enable=E0611
 
 # Disable PyLint complaining about 'invalid' names
@@ -50,65 +51,66 @@ from Foundation import NSData, NSString
 # this works around an issue with App Transport Security on 10.11
 bundle = NSBundle.mainBundle()
 info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
-info['NSAppTransportSecurity'] = {'NSAllowsArbitraryLoads': True}
+info["NSAppTransportSecurity"] = {"NSAllowsArbitraryLoads": True}
 
 
 ssl_error_codes = {
-    -9800: u'SSL protocol error',
-    -9801: u'Cipher Suite negotiation failure',
-    -9802: u'Fatal alert',
-    -9803: u'I/O would block (not fatal)',
-    -9804: u'Attempt to restore an unknown session',
-    -9805: u'Connection closed gracefully',
-    -9806: u'Connection closed via error',
-    -9807: u'Invalid certificate chain',
-    -9808: u'Bad certificate format',
-    -9809: u'Underlying cryptographic error',
-    -9810: u'Internal error',
-    -9811: u'Module attach failure',
-    -9812: u'Valid cert chain, untrusted root',
-    -9813: u'Cert chain not verified by root',
-    -9814: u'Chain had an expired cert',
-    -9815: u'Chain had a cert not yet valid',
-    -9816: u'Server closed session with no notification',
-    -9817: u'Insufficient buffer provided',
-    -9818: u'Bad SSLCipherSuite',
-    -9819: u'Unexpected message received',
-    -9820: u'Bad MAC',
-    -9821: u'Decryption failed',
-    -9822: u'Record overflow',
-    -9823: u'Decompression failure',
-    -9824: u'Handshake failure',
-    -9825: u'Misc. bad certificate',
-    -9826: u'Bad unsupported cert format',
-    -9827: u'Certificate revoked',
-    -9828: u'Certificate expired',
-    -9829: u'Unknown certificate',
-    -9830: u'Illegal parameter',
-    -9831: u'Unknown Cert Authority',
-    -9832: u'Access denied',
-    -9833: u'Decoding error',
-    -9834: u'Decryption error',
-    -9835: u'Export restriction',
-    -9836: u'Bad protocol version',
-    -9837: u'Insufficient security',
-    -9838: u'Internal error',
-    -9839: u'User canceled',
-    -9840: u'No renegotiation allowed',
-    -9841: u'Peer cert is valid, or was ignored if verification disabled',
-    -9842: u'Server has requested a client cert',
-    -9843: u'Peer host name mismatch',
-    -9844: u'Peer dropped connection before responding',
-    -9845: u'Decryption failure',
-    -9846: u'Bad MAC',
-    -9847: u'Record overflow',
-    -9848: u'Configuration error',
-    -9849: u'Unexpected (skipped) record in DTLS'}
+    -9800: u"SSL protocol error",
+    -9801: u"Cipher Suite negotiation failure",
+    -9802: u"Fatal alert",
+    -9803: u"I/O would block (not fatal)",
+    -9804: u"Attempt to restore an unknown session",
+    -9805: u"Connection closed gracefully",
+    -9806: u"Connection closed via error",
+    -9807: u"Invalid certificate chain",
+    -9808: u"Bad certificate format",
+    -9809: u"Underlying cryptographic error",
+    -9810: u"Internal error",
+    -9811: u"Module attach failure",
+    -9812: u"Valid cert chain, untrusted root",
+    -9813: u"Cert chain not verified by root",
+    -9814: u"Chain had an expired cert",
+    -9815: u"Chain had a cert not yet valid",
+    -9816: u"Server closed session with no notification",
+    -9817: u"Insufficient buffer provided",
+    -9818: u"Bad SSLCipherSuite",
+    -9819: u"Unexpected message received",
+    -9820: u"Bad MAC",
+    -9821: u"Decryption failed",
+    -9822: u"Record overflow",
+    -9823: u"Decompression failure",
+    -9824: u"Handshake failure",
+    -9825: u"Misc. bad certificate",
+    -9826: u"Bad unsupported cert format",
+    -9827: u"Certificate revoked",
+    -9828: u"Certificate expired",
+    -9829: u"Unknown certificate",
+    -9830: u"Illegal parameter",
+    -9831: u"Unknown Cert Authority",
+    -9832: u"Access denied",
+    -9833: u"Decoding error",
+    -9834: u"Decryption error",
+    -9835: u"Export restriction",
+    -9836: u"Bad protocol version",
+    -9837: u"Insufficient security",
+    -9838: u"Internal error",
+    -9839: u"User canceled",
+    -9840: u"No renegotiation allowed",
+    -9841: u"Peer cert is valid, or was ignored if verification disabled",
+    -9842: u"Server has requested a client cert",
+    -9843: u"Peer host name mismatch",
+    -9844: u"Peer dropped connection before responding",
+    -9845: u"Decryption failure",
+    -9846: u"Bad MAC",
+    -9847: u"Record overflow",
+    -9848: u"Configuration error",
+    -9849: u"Unexpected (skipped) record in DTLS",
+}
 
 
 class Purl(NSObject):
-    '''A class for getting content from a URL
-       using NSURLConnection and friends'''
+    """A class for getting content from a URL
+       using NSURLConnection and friends"""
 
     # since we inherit from NSObject, PyLint issues a few bogus warnings
     # pylint: disable=W0232,E1002
@@ -118,25 +120,24 @@ class Purl(NSObject):
     # pylint: disable=E1101,W0201
 
     def initWithOptions_(self, options):
-        '''Set up our Purl object'''
+        """Set up our Purl object"""
         self = super(Purl, self).init()
         if not self:
             return
 
-        self.follow_redirects = options.get('follow_redirects', False)
-        self.url = options.get('url')
-        self.method = options.get('method', 'GET')
-        self.additional_headers = options.get('additional_headers', {})
-        self.username = options.get('username')
-        self.password = options.get('password')
-        self.connection_timeout = options.get('connection_timeout', 10)
-        if options.get('content_type') is not None:
-            self.additional_headers['Content-Type'] = options.get(
-                'content_type')
-        self.body = options.get('body')
-        self.response_data = ''
+        self.follow_redirects = options.get("follow_redirects", False)
+        self.url = options.get("url")
+        self.method = options.get("method", "GET")
+        self.additional_headers = options.get("additional_headers", {})
+        self.username = options.get("username")
+        self.password = options.get("password")
+        self.connection_timeout = options.get("connection_timeout", 10)
+        if options.get("content_type") is not None:
+            self.additional_headers["Content-Type"] = options.get("content_type")
+        self.body = options.get("body")
+        self.response_data = ""
 
-        self.log = options.get('logging_function', NSLog)
+        self.log = options.get("logging_function", NSLog)
 
         self.response = None
         self.headers = None
@@ -149,95 +150,101 @@ class Purl(NSObject):
         return self
 
     def start(self):
-        '''Start the connection'''
+        """Start the connection"""
         url = NSURL.URLWithString_(self.url)
-        request = (
-            NSMutableURLRequest.requestWithURL_cachePolicy_timeoutInterval_(
-                url, NSURLRequestReloadIgnoringLocalCacheData,
-                self.connection_timeout))
+        request = NSMutableURLRequest.requestWithURL_cachePolicy_timeoutInterval_(
+            url, NSURLRequestReloadIgnoringLocalCacheData, self.connection_timeout
+        )
         if self.additional_headers:
             for header, value in self.additional_headers.items():
                 request.setValue_forHTTPHeaderField_(value, header)
         request.setHTTPMethod_(self.method)
-        
-        if self.method == 'POST':
+
+        if self.method == "POST":
             body_unicode = unicode(self.body)
-            body_data = NSData.dataWithBytes_length_(NSString.stringWithString_(
-                body_unicode).UTF8String(), len(body_unicode.encode('utf-8')))
+            body_data = NSData.dataWithBytes_length_(
+                NSString.stringWithString_(body_unicode).UTF8String(),
+                len(body_unicode.encode("utf-8")),
+            )
             request.setHTTPBody_(body_data)
 
         self.connection = NSURLConnection.alloc().initWithRequest_delegate_(
-            request, self)
+            request, self
+        )
 
     def cancel(self):
-        '''Cancel the connection'''
+        """Cancel the connection"""
         if self.connection:
             self.connection.cancel()
             self.done = True
 
     def isDone(self):
-        '''Check if the connection request is complete. As a side effect,
-        allow the delegates to work my letting the run loop run for a bit'''
+        """Check if the connection request is complete. As a side effect,
+        allow the delegates to work my letting the run loop run for a bit"""
         if self.done:
             return self.done
         # let the delegates do their thing
         NSRunLoop.currentRunLoop().runUntilDate_(
-            NSDate.dateWithTimeIntervalSinceNow_(.1))
+            NSDate.dateWithTimeIntervalSinceNow_(0.1)
+        )
         return self.done
 
     def get_response_data(self):
-        '''Return response data'''
+        """Return response data"""
         return self.response_data
 
     def connection_didFailWithError_(self, connection, error):
-        '''NSURLConnection delegate method
-        Sent when a connection fails to load its request successfully.'''
+        """NSURLConnection delegate method
+        Sent when a connection fails to load its request successfully."""
 
         # we don't actually use the connection argument, so
         # pylint: disable=W0613
 
         self.error = error
         # If this was an SSL error, try to extract the SSL error code.
-        if 'NSUnderlyingError' in error.userInfo():
-            ssl_code = error.userInfo()['NSUnderlyingError'].userInfo().get(
-                '_kCFNetworkCFStreamSSLErrorOriginalValue', None)
+        if "NSUnderlyingError" in error.userInfo():
+            ssl_code = (
+                error.userInfo()["NSUnderlyingError"]
+                .userInfo()
+                .get("_kCFNetworkCFStreamSSLErrorOriginalValue", None)
+            )
             if ssl_code:
-                self.SSLerror = (ssl_code, ssl_error_codes.get(
-                    ssl_code, 'Unknown SSL error'))
+                self.SSLerror = (
+                    ssl_code,
+                    ssl_error_codes.get(ssl_code, "Unknown SSL error"),
+                )
         self.done = True
 
-
     def connectionDidFinishLoading_(self, connection):
-        '''NSURLConnectionDataDelegat delegate method
-        Sent when a connection has finished loading successfully.'''
+        """NSURLConnectionDataDelegat delegate method
+        Sent when a connection has finished loading successfully."""
 
         # we don't actually use the connection argument, so
         # pylint: disable=W0613
 
         self.done = True
 
-
     def connection_didReceiveResponse_(self, connection, response):
-        '''NSURLConnectionDataDelegate delegate method
+        """NSURLConnectionDataDelegate delegate method
         Sent when the connection has received sufficient data to construct the
-        URL response for its request.'''
+        URL response for its request."""
 
         # we don't actually use the connection argument, so
         # pylint: disable=W0613
 
         self.response = response
 
-        if response.className() == u'NSHTTPURLResponse':
+        if response.className() == u"NSHTTPURLResponse":
             # Headers and status code only available for HTTP/S transfers
             self.status = response.statusCode()
             self.headers = dict(response.allHeaderFields())
 
-
     def connection_willSendRequest_redirectResponse_(
-            self, connection, request, response):
-        '''NSURLConnectionDataDelegate delegate method
+        self, connection, request, response
+    ):
+        """NSURLConnectionDataDelegate delegate method
         Sent when the connection determines that it must change URLs in order to
-        continue loading a request.'''
+        continue loading a request."""
 
         # we don't actually use the connection argument, so
         # pylint: disable=W0613
@@ -254,129 +261,156 @@ class Purl(NSObject):
         self.redirection.append([newURL, dict(response.allHeaderFields())])
         if self.follow_redirects:
             # Allow the redirect
-            self.log('Allowing redirect to: %s' % newURL)
+            self.log("Allowing redirect to: %s" % newURL)
             return request
         else:
             # Deny the redirect
-            self.log('Denying redirect to: %s' % newURL)
+            self.log("Denying redirect to: %s" % newURL)
             return None
 
     def connection_willSendRequestForAuthenticationChallenge_(
-            self, connection, challenge):
-        '''NSURLConnection delegate method
+        self, connection, challenge
+    ):
+        """NSURLConnection delegate method
         Tells the delegate that the connection will send a request for an
         authentication challenge.
-        New in 10.7.'''
+        New in 10.7."""
 
         # we don't actually use the connection argument, so
         # pylint: disable=W0613
 
-        self.log('connection_willSendRequestForAuthenticationChallenge_')
+        self.log("connection_willSendRequestForAuthenticationChallenge_")
         protectionSpace = challenge.protectionSpace()
         host = protectionSpace.host()
         realm = protectionSpace.realm()
         authenticationMethod = protectionSpace.authenticationMethod()
         self.log(
-            'Authentication challenge for Host: %s Realm: %s AuthMethod: %s'
-            % (host, realm, authenticationMethod))
+            "Authentication challenge for Host: %s Realm: %s AuthMethod: %s"
+            % (host, realm, authenticationMethod)
+        )
         if challenge.previousFailureCount() > 0:
             # we have the wrong credentials. just fail
-            self.log('Previous authentication attempt failed.')
+            self.log("Previous authentication attempt failed.")
             challenge.sender().cancelAuthenticationChallenge_(challenge)
-        if self.username and self.password and authenticationMethod in [
-                'NSURLAuthenticationMethodDefault',
-                'NSURLAuthenticationMethodHTTPBasic',
-                'NSURLAuthenticationMethodHTTPDigest']:
-            self.log('Will attempt to authenticate.')
-            self.log('Username: %s Password: %s'
-                     % (self.username, ('*' * len(self.password or ''))))
-            credential = (
-                NSURLCredential.credentialWithUser_password_persistence_(
-                    self.username, self.password,
-                    NSURLCredentialPersistenceNone))
+        if (
+            self.username
+            and self.password
+            and authenticationMethod
+            in [
+                "NSURLAuthenticationMethodDefault",
+                "NSURLAuthenticationMethodHTTPBasic",
+                "NSURLAuthenticationMethodHTTPDigest",
+            ]
+        ):
+            self.log("Will attempt to authenticate.")
+            self.log(
+                "Username: %s Password: %s"
+                % (self.username, ("*" * len(self.password or "")))
+            )
+            credential = NSURLCredential.credentialWithUser_password_persistence_(
+                self.username, self.password, NSURLCredentialPersistenceNone
+            )
             challenge.sender().useCredential_forAuthenticationChallenge_(
-                credential, challenge)
+                credential, challenge
+            )
         else:
             # fall back to system-provided default behavior
-            self.log('Allowing OS to handle authentication request')
-            challenge.sender(
-                ).performDefaultHandlingForAuthenticationChallenge_(
-                    challenge)
+            self.log("Allowing OS to handle authentication request")
+            challenge.sender().performDefaultHandlingForAuthenticationChallenge_(
+                challenge
+            )
 
     def connection_canAuthenticateAgainstProtectionSpace_(
-            self, connection, protectionSpace):
-        '''NSURLConnection delegate method
+        self, connection, protectionSpace
+    ):
+        """NSURLConnection delegate method
         Sent to determine whether the delegate is able to respond to a
         protection space’s form of authentication.
-        Deprecated in 10.10'''
+        Deprecated in 10.10"""
 
         # we don't actually use the connection argument, so
         # pylint: disable=W0613
 
         # this is not called in 10.5.x.
-        self.log('connection_canAuthenticateAgainstProtectionSpace_')
+        self.log("connection_canAuthenticateAgainstProtectionSpace_")
         if protectionSpace:
             host = protectionSpace.host()
             realm = protectionSpace.realm()
             authenticationMethod = protectionSpace.authenticationMethod()
-            self.log('Protection space found. Host: %s Realm: %s AuthMethod: %s'
-                     % (host, realm, authenticationMethod))
-            if self.username and self.password and authenticationMethod in [
-                    'NSURLAuthenticationMethodDefault',
-                    'NSURLAuthenticationMethodHTTPBasic',
-                    'NSURLAuthenticationMethodHTTPDigest']:
+            self.log(
+                "Protection space found. Host: %s Realm: %s AuthMethod: %s"
+                % (host, realm, authenticationMethod)
+            )
+            if (
+                self.username
+                and self.password
+                and authenticationMethod
+                in [
+                    "NSURLAuthenticationMethodDefault",
+                    "NSURLAuthenticationMethodHTTPBasic",
+                    "NSURLAuthenticationMethodHTTPDigest",
+                ]
+            ):
                 # we know how to handle this
-                self.log('Can handle this authentication request')
+                self.log("Can handle this authentication request")
                 return True
         # we don't know how to handle this; let the OS try
-        self.log('Allowing OS to handle authentication request')
+        self.log("Allowing OS to handle authentication request")
         return False
 
-    def connection_didReceiveAuthenticationChallenge_(
-            self, connection, challenge):
-        '''NSURLConnection delegate method
+    def connection_didReceiveAuthenticationChallenge_(self, connection, challenge):
+        """NSURLConnection delegate method
         Sent when a connection must authenticate a challenge in order to
         download its request.
-        Deprecated in 10.10'''
+        Deprecated in 10.10"""
 
         # we don't actually use the connection argument, so
         # pylint: disable=W0613
 
-        self.log('connection_didReceiveAuthenticationChallenge_')
+        self.log("connection_didReceiveAuthenticationChallenge_")
         protectionSpace = challenge.protectionSpace()
         host = protectionSpace.host()
         realm = protectionSpace.realm()
         authenticationMethod = protectionSpace.authenticationMethod()
         self.log(
-            'Authentication challenge for Host: %s Realm: %s AuthMethod: %s'
-            % (host, realm, authenticationMethod))
+            "Authentication challenge for Host: %s Realm: %s AuthMethod: %s"
+            % (host, realm, authenticationMethod)
+        )
         if challenge.previousFailureCount() > 0:
             # we have the wrong credentials. just fail
-            self.log('Previous authentication attempt failed.')
+            self.log("Previous authentication attempt failed.")
             challenge.sender().cancelAuthenticationChallenge_(challenge)
-        if self.username and self.password and authenticationMethod in [
-                'NSURLAuthenticationMethodDefault',
-                'NSURLAuthenticationMethodHTTPBasic',
-                'NSURLAuthenticationMethodHTTPDigest']:
-            self.log('Will attempt to authenticate.')
-            self.log('Username: %s Password: %s'
-                     % (self.username, ('*' * len(self.password or ''))))
-            credential = (
-                NSURLCredential.credentialWithUser_password_persistence_(
-                    self.username, self.password,
-                    NSURLCredentialPersistenceNone))
+        if (
+            self.username
+            and self.password
+            and authenticationMethod
+            in [
+                "NSURLAuthenticationMethodDefault",
+                "NSURLAuthenticationMethodHTTPBasic",
+                "NSURLAuthenticationMethodHTTPDigest",
+            ]
+        ):
+            self.log("Will attempt to authenticate.")
+            self.log(
+                "Username: %s Password: %s"
+                % (self.username, ("*" * len(self.password or "")))
+            )
+            credential = NSURLCredential.credentialWithUser_password_persistence_(
+                self.username, self.password, NSURLCredentialPersistenceNone
+            )
             challenge.sender().useCredential_forAuthenticationChallenge_(
-                credential, challenge)
+                credential, challenge
+            )
         else:
             # fall back to system-provided default behavior
-            self.log('Continuing without credential.')
-            challenge.sender(
-                ).continueWithoutCredentialForAuthenticationChallenge_(
-                    challenge)
+            self.log("Continuing without credential.")
+            challenge.sender().continueWithoutCredentialForAuthenticationChallenge_(
+                challenge
+            )
 
     def connection_didReceiveData_(self, connection, data):
-        '''NSURLConnectionDataDelegate method
-        Sent as a connection loads data incrementally'''
+        """NSURLConnectionDataDelegate method
+        Sent as a connection loads data incrementally"""
 
         # we don't actually use the connection argument, so
         # pylint: disable=W0613

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/purl.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/purl.py
@@ -17,13 +17,12 @@
 #
 # Adaptation of purl.py by Michael Lynn
 # https://gist.github.com/pudquick/a73d0ce7cd8730c97491
-"""
-purl.py
+"""purl.py.
 
 Created by Greg Neagle on 2013-11-21.
 Modified by Arjen van Bochoven on 2015-09-23
 
-curl replacement using NSURLConnection and friends 
+curl replacement using NSURLConnection and friends
 """
 
 # builtin super doesn't work with Cocoa classes in recent PyObjC releases.
@@ -109,8 +108,8 @@ ssl_error_codes = {
 
 
 class Purl(NSObject):
-    """A class for getting content from a URL
-       using NSURLConnection and friends"""
+    """A class for getting content from a URL using NSURLConnection and
+    friends."""
 
     # since we inherit from NSObject, PyLint issues a few bogus warnings
     # pylint: disable=W0232,E1002
@@ -120,7 +119,7 @@ class Purl(NSObject):
     # pylint: disable=E1101,W0201
 
     def initWithOptions_(self, options):
-        """Set up our Purl object"""
+        """Set up our Purl object."""
         self = super(Purl, self).init()
         if not self:
             return
@@ -150,7 +149,7 @@ class Purl(NSObject):
         return self
 
     def start(self):
-        """Start the connection"""
+        """Start the connection."""
         url = NSURL.URLWithString_(self.url)
         request = NSMutableURLRequest.requestWithURL_cachePolicy_timeoutInterval_(
             url, NSURLRequestReloadIgnoringLocalCacheData, self.connection_timeout
@@ -173,14 +172,17 @@ class Purl(NSObject):
         )
 
     def cancel(self):
-        """Cancel the connection"""
+        """Cancel the connection."""
         if self.connection:
             self.connection.cancel()
             self.done = True
 
     def isDone(self):
-        """Check if the connection request is complete. As a side effect,
-        allow the delegates to work my letting the run loop run for a bit"""
+        """Check if the connection request is complete.
+
+        As a side effect, allow the delegates to work my letting the run
+        loop run for a bit
+        """
         if self.done:
             return self.done
         # let the delegates do their thing
@@ -190,12 +192,12 @@ class Purl(NSObject):
         return self.done
 
     def get_response_data(self):
-        """Return response data"""
+        """Return response data."""
         return self.response_data
 
     def connection_didFailWithError_(self, connection, error):
-        """NSURLConnection delegate method
-        Sent when a connection fails to load its request successfully."""
+        """NSURLConnection delegate method Sent when a connection fails to load
+        its request successfully."""
 
         # we don't actually use the connection argument, so
         # pylint: disable=W0613
@@ -216,8 +218,8 @@ class Purl(NSObject):
         self.done = True
 
     def connectionDidFinishLoading_(self, connection):
-        """NSURLConnectionDataDelegat delegate method
-        Sent when a connection has finished loading successfully."""
+        """NSURLConnectionDataDelegat delegate method Sent when a connection
+        has finished loading successfully."""
 
         # we don't actually use the connection argument, so
         # pylint: disable=W0613
@@ -225,9 +227,9 @@ class Purl(NSObject):
         self.done = True
 
     def connection_didReceiveResponse_(self, connection, response):
-        """NSURLConnectionDataDelegate delegate method
-        Sent when the connection has received sufficient data to construct the
-        URL response for its request."""
+        """NSURLConnectionDataDelegate delegate method Sent when the connection
+        has received sufficient data to construct the URL response for its
+        request."""
 
         # we don't actually use the connection argument, so
         # pylint: disable=W0613
@@ -242,9 +244,9 @@ class Purl(NSObject):
     def connection_willSendRequest_redirectResponse_(
         self, connection, request, response
     ):
-        """NSURLConnectionDataDelegate delegate method
-        Sent when the connection determines that it must change URLs in order to
-        continue loading a request."""
+        """NSURLConnectionDataDelegate delegate method Sent when the connection
+        determines that it must change URLs in order to continue loading a
+        request."""
 
         # we don't actually use the connection argument, so
         # pylint: disable=W0613
@@ -271,10 +273,11 @@ class Purl(NSObject):
     def connection_willSendRequestForAuthenticationChallenge_(
         self, connection, challenge
     ):
-        """NSURLConnection delegate method
-        Tells the delegate that the connection will send a request for an
-        authentication challenge.
-        New in 10.7."""
+        """NSURLConnection delegate method Tells the delegate that the
+        connection will send a request for an authentication challenge.
+
+        New in 10.7.
+        """
 
         # we don't actually use the connection argument, so
         # pylint: disable=W0613
@@ -323,10 +326,12 @@ class Purl(NSObject):
     def connection_canAuthenticateAgainstProtectionSpace_(
         self, connection, protectionSpace
     ):
-        """NSURLConnection delegate method
-        Sent to determine whether the delegate is able to respond to a
-        protection space’s form of authentication.
-        Deprecated in 10.10"""
+        """NSURLConnection delegate method Sent to determine whether the
+        delegate is able to respond to a protection space’s form of
+        authentication.
+
+        Deprecated in 10.10
+        """
 
         # we don't actually use the connection argument, so
         # pylint: disable=W0613
@@ -359,10 +364,11 @@ class Purl(NSObject):
         return False
 
     def connection_didReceiveAuthenticationChallenge_(self, connection, challenge):
-        """NSURLConnection delegate method
-        Sent when a connection must authenticate a challenge in order to
-        download its request.
-        Deprecated in 10.10"""
+        """NSURLConnection delegate method Sent when a connection must
+        authenticate a challenge in order to download its request.
+
+        Deprecated in 10.10
+        """
 
         # we don't actually use the connection argument, so
         # pylint: disable=W0613
@@ -409,8 +415,8 @@ class Purl(NSObject):
             )
 
     def connection_didReceiveData_(self, connection, data):
-        """NSURLConnectionDataDelegate method
-        Sent as a connection loads data incrementally"""
+        """NSURLConnectionDataDelegate method Sent as a connection loads data
+        incrementally."""
 
         # we don't actually use the connection argument, so
         # pylint: disable=W0613

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/reportcommon.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/reportcommon.py
@@ -31,15 +31,18 @@ from Foundation import kCFPreferencesCurrentUser
 from Foundation import kCFPreferencesCurrentHost
 from Foundation import NSHTTPURLResponse
 from SystemConfiguration import SCDynamicStoreCopyConsoleUser
+
 # pylint: enable=E0611
 
 # our preferences "bundle_id"
-BUNDLE_ID = 'MunkiReport'
+BUNDLE_ID = "MunkiReport"
+
 
 class CurlError(Exception):
     def __init__(self, status, message):
         display_error(message)
         exit(0)
+
 
 def set_verbosity(level):
     """
@@ -47,23 +50,27 @@ def set_verbosity(level):
     """
     display.verbose = int(level)
 
+
 def display_error(msg, *args):
     """
     Call display error msg handler
     """
-    display.display_error('%s' % msg, *args)
+    display.display_error("%s" % msg, *args)
+
 
 def display_warning(msg, *args):
     """
     Call display warning msg handler
     """
-    display.display_warning('%s' % msg, *args)
+    display.display_warning("%s" % msg, *args)
+
 
 def display_detail(msg, *args):
     """
     Call display detail msg handler
     """
-    display.display_detail('%s' % msg, *args)
+    display.display_detail("%s" % msg, *args)
+
 
 def curl(url, values):
 
@@ -74,20 +81,22 @@ def curl(url, values):
     options["body"] = urlencode(values)
     options["logging_function"] = display_detail
     options["connection_timeout"] = 60
-    if pref('UseMunkiAdditionalHttpHeaders'):
-        custom_headers = prefs.pref(
-                            constants.ADDITIONAL_HTTP_HEADERS_KEY)
+    if pref("UseMunkiAdditionalHttpHeaders"):
+        custom_headers = prefs.pref(constants.ADDITIONAL_HTTP_HEADERS_KEY)
         if custom_headers:
             options["additional_headers"] = dict()
             for header in custom_headers:
-                m = re.search(r'^(?P<header_name>.*?): (?P<header_value>.*?)$',
-                    header)
+                m = re.search(r"^(?P<header_name>.*?): (?P<header_value>.*?)$", header)
                 if m:
-                    options["additional_headers"][
-                            m.group('header_name')] = m.group('header_value')
+                    options["additional_headers"][m.group("header_name")] = m.group(
+                        "header_value"
+                    )
         else:
-            raise CurlError(-1, 'UseMunkiAdditionalHttpHeaders defined, '
-                                'but not found in Munki preferences')
+            raise CurlError(
+                -1,
+                "UseMunkiAdditionalHttpHeaders defined, "
+                "but not found in Munki preferences",
+            )
 
     # Build Purl with initial settings
     connection = Purl.alloc().initWithOptions_(options)
@@ -103,7 +112,7 @@ def curl(url, values):
         # safely kill the connection then re-raise
         connection.cancel()
         raise
-    except Exception, err: # too general, I know
+    except Exception, err:  # too general, I know
         # Let us out! ... Safely! Unexpectedly quit dialogs are annoying...
         connection.cancel()
         # Re-raise the error as a GurlError
@@ -112,101 +121,138 @@ def curl(url, values):
     if connection.error != None:
         # Gurl returned an error
         display.display_detail(
-            'Download error %s: %s', connection.error.code(),
-            connection.error.localizedDescription())
+            "Download error %s: %s",
+            connection.error.code(),
+            connection.error.localizedDescription(),
+        )
         if connection.SSLerror:
-            display_detail(
-                'SSL error detail: %s', str(connection.SSLerror))
-        display_detail('Headers: %s', connection.headers)
-        raise CurlError(connection.error.code(),
-                        connection.error.localizedDescription())
+            display_detail("SSL error detail: %s", str(connection.SSLerror))
+        display_detail("Headers: %s", connection.headers)
+        raise CurlError(
+            connection.error.code(), connection.error.localizedDescription()
+        )
 
     if connection.response != None and connection.status != 200:
-        display.display_detail('Status: %s', connection.status)
-        display.display_detail('Headers: %s', connection.headers)
+        display.display_detail("Status: %s", connection.status)
+        display.display_detail("Headers: %s", connection.headers)
     if connection.redirection != []:
-        display.display_detail('Redirection: %s', connection.redirection)
+        display.display_detail("Redirection: %s", connection.redirection)
 
-    connection.headers['http_result_code'] = str(connection.status)
-    description = NSHTTPURLResponse.localizedStringForStatusCode_(
-                                                            connection.status)
-    connection.headers['http_result_description'] = description
+    connection.headers["http_result_code"] = str(connection.status)
+    description = NSHTTPURLResponse.localizedStringForStatusCode_(connection.status)
+    connection.headers["http_result_description"] = description
 
-    if str(connection.status).startswith('2'):
+    if str(connection.status).startswith("2"):
         return connection.get_response_data()
     else:
         # there was an HTTP error of some sort.
-        raise CurlError(connection.status,
-            '%s failed, HTTP returncode %s (%s)' % (
+        raise CurlError(
+            connection.status,
+            "%s failed, HTTP returncode %s (%s)"
+            % (
                 url,
                 connection.status,
-                connection.headers.get('http_result_description', 'Failed')))
+                connection.headers.get("http_result_description", "Failed"),
+            ),
+        )
+
 
 def get_hardware_info():
-    '''Uses system profiler to get hardware info for this machine'''
-    cmd = ['/usr/sbin/system_profiler', 'SPHardwareDataType', '-xml']
-    proc = subprocess.Popen(cmd, shell=False, bufsize=-1,
-                            stdin=subprocess.PIPE,
-                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    """Uses system profiler to get hardware info for this machine"""
+    cmd = ["/usr/sbin/system_profiler", "SPHardwareDataType", "-xml"]
+    proc = subprocess.Popen(
+        cmd,
+        shell=False,
+        bufsize=-1,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
     (output, dummy_error) = proc.communicate()
     try:
         plist = FoundationPlist.readPlistFromString(output)
         # system_profiler xml is an array
         sp_dict = plist[0]
-        items = sp_dict['_items']
+        items = sp_dict["_items"]
         sp_hardware_dict = items[0]
         return sp_hardware_dict
     except BaseException:
         return {}
 
+
 def get_long_username(username):
     try:
         long_name = pwd.getpwnam(username)[4]
     except:
-        long_name = ''
-    return long_name.decode('utf-8')
+        long_name = ""
+    return long_name.decode("utf-8")
+
 
 def get_uid(username):
     try:
         uid = pwd.getpwnam(username)[2]
     except:
-        uid = ''
+        uid = ""
     return uid
 
+
 def get_computername():
-    cmd = ['/usr/sbin/scutil', '--get', 'ComputerName']
-    proc = subprocess.Popen(cmd, shell=False, bufsize=-1,
-                            stdin=subprocess.PIPE,
-                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    cmd = ["/usr/sbin/scutil", "--get", "ComputerName"]
+    proc = subprocess.Popen(
+        cmd,
+        shell=False,
+        bufsize=-1,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
     (output, unused_error) = proc.communicate()
     output = output.strip()
-    return output.decode('utf-8')
+    return output.decode("utf-8")
+
 
 def get_cpuinfo():
-    cmd = ['/usr/sbin/sysctl', '-n', 'machdep.cpu.brand_string']
-    proc = subprocess.Popen(cmd, shell=False, bufsize=-1,
-                            stdin=subprocess.PIPE,
-                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    cmd = ["/usr/sbin/sysctl", "-n", "machdep.cpu.brand_string"]
+    proc = subprocess.Popen(
+        cmd,
+        shell=False,
+        bufsize=-1,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
     (output, unused_error) = proc.communicate()
     output = output.strip()
-    return output.decode('utf-8')
+    return output.decode("utf-8")
+
 
 def get_buildversion():
-    cmd = ['/usr/bin/sw_vers', '-buildVersion']
-    proc = subprocess.Popen(cmd, shell=False, bufsize=-1,
-                            stdin=subprocess.PIPE,
-                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    cmd = ["/usr/bin/sw_vers", "-buildVersion"]
+    proc = subprocess.Popen(
+        cmd,
+        shell=False,
+        bufsize=-1,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
     (output, unused_error) = proc.communicate()
     output = output.strip()
-    return output.decode('utf-8')
+    return output.decode("utf-8")
+
 
 def get_uptime():
-    cmd = ['/usr/sbin/sysctl', '-n', 'kern.boottime']
-    proc = subprocess.Popen(cmd, shell=False, bufsize=-1,
-                            stdin=subprocess.PIPE,
-                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    cmd = ["/usr/sbin/sysctl", "-n", "kern.boottime"]
+    proc = subprocess.Popen(
+        cmd,
+        shell=False,
+        bufsize=-1,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
     (output, unused_error) = proc.communicate()
-    sec = int(re.sub('.*sec = (\d+),.*', '\\1', output))
+    sec = int(re.sub(".*sec = (\d+),.*", "\\1", output))
     up = int(time.time() - sec)
     return up if up > 0 else -1
 
@@ -214,14 +260,22 @@ def get_uptime():
 def set_pref(pref_name, pref_value):
     """Sets a preference, See prefs.py for details"""
     CFPreferencesSetValue(
-        pref_name, pref_value, BUNDLE_ID,
-        kCFPreferencesAnyUser, kCFPreferencesCurrentHost)
+        pref_name,
+        pref_value,
+        BUNDLE_ID,
+        kCFPreferencesAnyUser,
+        kCFPreferencesCurrentHost,
+    )
     CFPreferencesAppSynchronize(BUNDLE_ID)
     print "set pref"
     try:
         CFPreferencesSetValue(
-            pref_name, pref_value, BUNDLE_ID,
-            kCFPreferencesAnyUser, kCFPreferencesCurrentHost)
+            pref_name,
+            pref_value,
+            BUNDLE_ID,
+            kCFPreferencesAnyUser,
+            kCFPreferencesCurrentHost,
+        )
         CFPreferencesAppSynchronize(BUNDLE_ID)
     except Exception:
         pass
@@ -233,38 +287,36 @@ def pref(pref_name):
     pref_value = CFPreferencesCopyAppValue(pref_name, BUNDLE_ID)
     return pref_value
 
+
 def process(serial, items):
     """Process receives a list of items, checks if they need updating
     and updates them if necessary"""
 
     # Sanitize serial
-    serial = ''.join([c for c in serial if c.isalnum()])
+    serial = "".join([c for c in serial if c.isalnum()])
 
     # Get prefs
-    baseurl = pref('BaseUrl') or \
-              prefs.pref('SoftwareRepoURL') + '/report/'
+    baseurl = pref("BaseUrl") or prefs.pref("SoftwareRepoURL") + "/report/"
 
     hashurl = baseurl + "index.php?/report/hash_check"
     checkurl = baseurl + "index.php?/report/check_in"
 
     # Get passphrase
-    passphrase = pref('Passphrase')
+    passphrase = pref("Passphrase")
 
     # Get hashes for all scripts
     for key, i in items.items():
-        if i.get('path'):
-            i['hash'] = getmd5hash(i.get('path'))
+        if i.get("path"):
+            i["hash"] = getmd5hash(i.get("path"))
 
     # Check dict
     check = {}
     for key, i in items.items():
-        if i.get('hash'):
-            check[key] = {'hash': i.get('hash')}
+        if i.get("hash"):
+            check[key] = {"hash": i.get("hash")}
 
     # Send hashes to server
-    values = {'serial': serial,\
-             'items': serialize(check),\
-             'passphrase' : passphrase}
+    values = {"serial": serial, "items": serialize(check), "passphrase": passphrase}
     server_data = curl(hashurl, values)
     # = response.read()
 
@@ -272,48 +324,51 @@ def process(serial, items):
     try:
         result = unserialize(server_data)
     except Exception, e:
-        display_error('Could not unserialize server data: %s' % str(e))
-        display_error('Request: %s' % str(values))
-        display_error('Response: %s' % str(server_data))
+        display_error("Could not unserialize server data: %s" % str(e))
+        display_error("Request: %s" % str(values))
+        display_error("Response: %s" % str(server_data))
         return -1
 
-    if result.get('error') != '':
-        display_error('Server error: %s' % result['error'])
+    if result.get("error") != "":
+        display_error("Server error: %s" % result["error"])
         return -1
 
-    if result.get('info') != '':
-        display_detail('Server info: %s' % result['info'])
+    if result.get("info") != "":
+        display_detail("Server info: %s" % result["info"])
 
     # Retrieve hashes that need updating
     total_size = 0
     for i in items.keys():
         if i in result:
-            if items[i].get('path'):
+            if items[i].get("path"):
                 try:
-                    f = open(items[i]['path'], "r")
-                    items[i]['data'] = f.read()
+                    f = open(items[i]["path"], "r")
+                    items[i]["data"] = f.read()
                 except:
-                    display_warning("Can't open %s" % items[i]['path'])
+                    display_warning("Can't open %s" % items[i]["path"])
                     del items[i]
                     continue
-            size = len(items[i]['data'])
-            display_detail('Need to update %s (%s)' % (i, sizeof_fmt(size)))
+            size = len(items[i]["data"])
+            display_detail("Need to update %s (%s)" % (i, sizeof_fmt(size)))
             total_size = total_size + size
-        else: # delete items that don't have to be uploaded
+        else:  # delete items that don't have to be uploaded
             del items[i]
 
     # Send new files with hashes
     if len(items):
-        display_detail('Sending items (%s)' % sizeof_fmt(total_size))
-        response = curl(checkurl, {'serial': serial,\
-             'items': serialize(items),\
-             'passphrase': passphrase})
+        display_detail("Sending items (%s)" % sizeof_fmt(total_size))
+        response = curl(
+            checkurl,
+            {"serial": serial, "items": serialize(items), "passphrase": passphrase},
+        )
         display_detail(response)
     else:
-        display_detail('No changes')
+        display_detail("No changes")
 
-def runExternalScriptWithTimeout(script, allow_insecure=False,\
-        script_args=(), timeout=30):
+
+def runExternalScriptWithTimeout(
+    script, allow_insecure=False, script_args=(), timeout=30
+):
     """Run a script (e.g. preflight/postflight) and return its exit status.
 
     Args:
@@ -329,29 +384,37 @@ def runExternalScriptWithTimeout(script, allow_insecure=False,\
     from munkilib import utils
 
     if not os.path.exists(script):
-        raise ScriptNotFoundError('script does not exist: %s' % script)
+        raise ScriptNotFoundError("script does not exist: %s" % script)
 
     if not allow_insecure:
         try:
             utils.verifyFileOnlyWritableByMunkiAndRoot(script)
         except utils.VerifyFilePermissionsError, e:
-            msg = ('Skipping execution due to failed file permissions '
-                   'verification: %s\n%s' % (script, str(e)))
+            msg = (
+                "Skipping execution due to failed file permissions "
+                "verification: %s\n%s" % (script, str(e))
+            )
             raise utils.RunExternalScriptError(msg)
 
     if os.access(script, os.X_OK):
         cmd = [script]
         if script_args:
             cmd.extend(script_args)
-        proc = subprocess.Popen(cmd, shell=False,
-                                stdin=subprocess.PIPE,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
+        proc = subprocess.Popen(
+            cmd,
+            shell=False,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
         while timeout > 0:
             if proc.poll() is not None:
                 (stdout, stderr) = proc.communicate()
-                return proc.returncode, stdout.decode('UTF-8', 'replace'), \
-                                        stderr.decode('UTF-8', 'replace')
+                return (
+                    proc.returncode,
+                    stdout.decode("UTF-8", "replace"),
+                    stderr.decode("UTF-8", "replace"),
+                )
             time.sleep(0.1)
             timeout -= 0.1
         else:
@@ -360,13 +423,14 @@ def runExternalScriptWithTimeout(script, allow_insecure=False,\
             except OSError, e:
                 if e.errno != 3:
                     raise
-            raise utils.RunExternalScriptError('%s timed out' % script)
+            raise utils.RunExternalScriptError("%s timed out" % script)
         return (0, None, None)
 
     else:
-        raise utils.RunExternalScriptError('%s not executable' % script)
+        raise utils.RunExternalScriptError("%s not executable" % script)
 
-def rundir(scriptdir, runtype, abort=False, submitscript=''):
+
+def rundir(scriptdir, runtype, abort=False, submitscript=""):
     """
     Run scripts in directory scriptdir
     runtype is passed to the script
@@ -379,13 +443,13 @@ def rundir(scriptdir, runtype, abort=False, submitscript=''):
 
         # Get timeout for scripts
         scriptTimeOut = 30
-        if pref('scriptTimeOut'):
-            scriptTimeOut = int(pref('scriptTimeOut'))
-            display_detail('# Set custom script timeout to %s seconds' % scriptTimeOut)
+        if pref("scriptTimeOut"):
+            scriptTimeOut = int(pref("scriptTimeOut"))
+            display_detail("# Set custom script timeout to %s seconds" % scriptTimeOut)
 
         # Directory containing the scripts
         parentdir = os.path.basename(scriptdir)
-        display_detail('# Executing scripts in %s' % parentdir)
+        display_detail("# Executing scripts in %s" % parentdir)
 
         # Get all files in scriptdir
         files = os.listdir(scriptdir)
@@ -399,12 +463,12 @@ def rundir(scriptdir, runtype, abort=False, submitscript=''):
                 sub = files.pop(files.index(submitscript))
                 files.append(sub)
             except Exception, e:
-                display_error('%s not found in %s' % (submitscript, parentdir))
+                display_error("%s not found in %s" % (submitscript, parentdir))
 
         for script in files:
 
             # Skip files that start with a period
-            if script.startswith('.'):
+            if script.startswith("."):
                 continue
 
             # Concatenate dir and filename
@@ -416,35 +480,36 @@ def rundir(scriptdir, runtype, abort=False, submitscript=''):
 
             try:
                 # Attempt to execute script
-                display_detail('Running %s' % script)
+                display_detail("Running %s" % script)
                 result, stdout, stderr = runExternalScriptWithTimeout(
-                    scriptpath, \
-                    allow_insecure=False, \
-                    script_args=[runtype], \
-                    timeout=scriptTimeOut)
+                    scriptpath,
+                    allow_insecure=False,
+                    script_args=[runtype],
+                    timeout=scriptTimeOut,
+                )
                 if stdout:
                     display_detail(stdout)
                 if stderr:
-                    display_detail('%s Error: %s' % (script, stderr))
+                    display_detail("%s Error: %s" % (script, stderr))
                 if result:
                     if abort:
-                        display_detail('Aborted by %s' % script)
+                        display_detail("Aborted by %s" % script)
                         exit(1)
                     else:
-                        display_warning('%s return code: %d'\
-                            % (script, result))
+                        display_warning("%s return code: %d" % (script, result))
 
             except utils.ScriptNotFoundError:
                 pass  # Script has disappeared - pass.
             except Exception, e:
                 display_warning("%s: %s" % (script, str(e)))
 
+
 def sizeof_fmt(num):
-    for unit in ['B','KB','MB','GB','TB','PB','EB','ZB']:
+    for unit in ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB"]:
         if abs(num) < 1000.0:
             return "%.0f%s" % (num, unit)
         num /= 1000.0
-    return "%.1f%s" % (num, 'YB')
+    return "%.1f%s" % (num, "YB")
 
 
 def gethash(filename, hash_function):
@@ -460,11 +525,11 @@ def gethash(filename, hash_function):
       The hashvalue of the given file as hex string.
     """
     if not os.path.isfile(filename):
-        return 'NOT A FILE'
+        return "NOT A FILE"
 
-    fileref = open(filename, 'rb')
+    fileref = open(filename, "rb")
     while 1:
-        chunk = fileref.read(2**16)
+        chunk = fileref.read(2 ** 16)
         if not chunk:
             break
         hash_function.update(chunk)
@@ -487,13 +552,13 @@ def getOsVersion(only_major_minor=True, as_tuple=False):
       only_major_minor: Boolean. If True, only include major/minor versions.
       as_tuple: Boolean. If True, return a tuple of ints, otherwise a string.
     """
-    os_version_tuple = platform.mac_ver()[0].split('.')
+    os_version_tuple = platform.mac_ver()[0].split(".")
     if only_major_minor:
         os_version_tuple = os_version_tuple[0:2]
     if as_tuple:
         return tuple(map(int, os_version_tuple))
     else:
-        return '.'.join(os_version_tuple)
+        return ".".join(os_version_tuple)
 
 
 def getconsoleuser():

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/reportcommon.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/reportcommon.py
@@ -45,30 +45,22 @@ class CurlError(Exception):
 
 
 def set_verbosity(level):
-    """
-    Set verbosity level
-    """
+    """Set verbosity level."""
     display.verbose = int(level)
 
 
 def display_error(msg, *args):
-    """
-    Call display error msg handler
-    """
+    """Call display error msg handler."""
     display.display_error("%s" % msg, *args)
 
 
 def display_warning(msg, *args):
-    """
-    Call display warning msg handler
-    """
+    """Call display warning msg handler."""
     display.display_warning("%s" % msg, *args)
 
 
 def display_detail(msg, *args):
-    """
-    Call display detail msg handler
-    """
+    """Call display detail msg handler."""
     display.display_detail("%s" % msg, *args)
 
 
@@ -158,7 +150,7 @@ def curl(url, values):
 
 
 def get_hardware_info():
-    """Uses system profiler to get hardware info for this machine"""
+    """Uses system profiler to get hardware info for this machine."""
     cmd = ["/usr/sbin/system_profiler", "SPHardwareDataType", "-xml"]
     proc = subprocess.Popen(
         cmd,
@@ -258,7 +250,7 @@ def get_uptime():
 
 
 def set_pref(pref_name, pref_value):
-    """Sets a preference, See prefs.py for details"""
+    """Sets a preference, See prefs.py for details."""
     CFPreferencesSetValue(
         pref_name,
         pref_value,
@@ -282,15 +274,17 @@ def set_pref(pref_name, pref_value):
 
 
 def pref(pref_name):
-    """Return a preference. See prefs.py for details
+    """Return a preference.
+
+    See prefs.py for details
     """
     pref_value = CFPreferencesCopyAppValue(pref_name, BUNDLE_ID)
     return pref_value
 
 
 def process(serial, items):
-    """Process receives a list of items, checks if they need updating
-    and updates them if necessary"""
+    """Process receives a list of items, checks if they need updating and
+    updates them if necessary."""
 
     # Sanitize serial
     serial = "".join([c for c in serial if c.isalnum()])
@@ -431,12 +425,9 @@ def runExternalScriptWithTimeout(
 
 
 def rundir(scriptdir, runtype, abort=False, submitscript=""):
-    """
-    Run scripts in directory scriptdir
-    runtype is passed to the script
-    if abort is True, a non-zero exit status will abort munki
-    submitscript is put at the end of the scriptlist
-    """
+    """Run scripts in directory scriptdir runtype is passed to the script if
+    abort is True, a non-zero exit status will abort munki submitscript is put
+    at the end of the scriptlist."""
     if os.path.exists(scriptdir):
 
         from munkilib import utils
@@ -513,8 +504,7 @@ def sizeof_fmt(num):
 
 
 def gethash(filename, hash_function):
-    """
-    Calculates the hashvalue of the given file with the given hash_function.
+    """Calculates the hashvalue of the given file with the given hash_function.
 
     Args:
       filename: The file name to calculate the hash value of.
@@ -538,9 +528,7 @@ def gethash(filename, hash_function):
 
 
 def getmd5hash(filename):
-    """
-    Returns hex of MD5 checksum of a file
-    """
+    """Returns hex of MD5 checksum of a file."""
     hash_function = hashlib.md5()
     return gethash(filename, hash_function)
 
@@ -562,7 +550,7 @@ def getOsVersion(only_major_minor=True, as_tuple=False):
 
 
 def getconsoleuser():
-    """Return console user"""
+    """Return console user."""
     cfuser = SCDynamicStoreCopyConsoleUser(None, None, None)
     return cfuser[0]
 

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/reports.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/reports.py
@@ -13,8 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-reports.py
+"""reports.py.
 
 Created by Greg Neagle on 2016-12-14.
 
@@ -42,7 +41,9 @@ from . import FoundationPlist
 def format_time(timestamp=None):
     """Return timestamp as an ISO 8601 formatted string, in the current
     timezone.
-    If timestamp isn't given the current time is used."""
+
+    If timestamp isn't given the current time is used.
+    """
     if timestamp is None:
         return str(NSDate.new())
     else:
@@ -50,7 +51,7 @@ def format_time(timestamp=None):
 
 
 def printreportitem(label, value, indent=0):
-    """Prints a report item in an 'attractive' way"""
+    """Prints a report item in an 'attractive' way."""
     indentspace = "    "
     if type(value) == type(None):
         print indentspace * indent, "%s: !NONE!" % label
@@ -71,13 +72,13 @@ def printreportitem(label, value, indent=0):
 
 
 def printreport(reportdict):
-    """Prints the report dictionary in a pretty(?) way"""
+    """Prints the report dictionary in a pretty(?) way."""
     for key in reportdict.keys():
         printreportitem(key, reportdict[key])
 
 
 def savereport():
-    """Save our report"""
+    """Save our report."""
     FoundationPlist.writePlist(
         report,
         os.path.join(prefs.pref("ManagedInstallDir"), "ManagedInstallReport.plist"),
@@ -85,7 +86,7 @@ def savereport():
 
 
 def readreport():
-    """Read report data from file"""
+    """Read report data from file."""
     global report
     reportfile = os.path.join(
         prefs.pref("ManagedInstallDir"), "ManagedInstallReport.plist"
@@ -98,7 +99,10 @@ def readreport():
 
 def _warn(msg):
     """We can't use display module functions here because that would require
-    circular imports. So a partial reimplementation."""
+    circular imports.
+
+    So a partial reimplementation.
+    """
     warning = "WARNING: %s" % msg
     print >> sys.stderr, warning.encode("UTF-8")
     munkilog.log(warning)
@@ -107,7 +111,7 @@ def _warn(msg):
 
 
 def archive_report():
-    """Archive a report"""
+    """Archive a report."""
     reportfile = os.path.join(
         prefs.pref("ManagedInstallDir"), "ManagedInstallReport.plist"
     )

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/reports.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/reports.py
@@ -31,6 +31,7 @@ import time
 # No name 'Foo' in module 'Bar' warnings. Disable them.
 # pylint: disable=E0611
 from Foundation import NSDate
+
 # pylint: enable=E0611
 
 from . import munkilog
@@ -50,23 +51,23 @@ def format_time(timestamp=None):
 
 def printreportitem(label, value, indent=0):
     """Prints a report item in an 'attractive' way"""
-    indentspace = '    '
+    indentspace = "    "
     if type(value) == type(None):
-        print indentspace*indent, '%s: !NONE!' % label
-    elif type(value) == list or type(value).__name__ == 'NSCFArray':
+        print indentspace * indent, "%s: !NONE!" % label
+    elif type(value) == list or type(value).__name__ == "NSCFArray":
         if label:
-            print indentspace*indent, '%s:' % label
+            print indentspace * indent, "%s:" % label
         index = 0
         for item in value:
             index += 1
-            printreportitem(index, item, indent+1)
-    elif type(value) == dict or type(value).__name__ == 'NSCFDictionary':
+            printreportitem(index, item, indent + 1)
+    elif type(value) == dict or type(value).__name__ == "NSCFDictionary":
         if label:
-            print indentspace*indent, '%s:' % label
+            print indentspace * indent, "%s:" % label
         for subkey in value.keys():
-            printreportitem(subkey, value[subkey], indent+1)
+            printreportitem(subkey, value[subkey], indent + 1)
     else:
-        print indentspace*indent, '%s: %s' % (label, value)
+        print indentspace * indent, "%s: %s" % (label, value)
 
 
 def printreport(reportdict):
@@ -78,15 +79,17 @@ def printreport(reportdict):
 def savereport():
     """Save our report"""
     FoundationPlist.writePlist(
-        report, os.path.join(
-            prefs.pref('ManagedInstallDir'), 'ManagedInstallReport.plist'))
+        report,
+        os.path.join(prefs.pref("ManagedInstallDir"), "ManagedInstallReport.plist"),
+    )
 
 
 def readreport():
     """Read report data from file"""
     global report
     reportfile = os.path.join(
-        prefs.pref('ManagedInstallDir'), 'ManagedInstallReport.plist')
+        prefs.pref("ManagedInstallDir"), "ManagedInstallReport.plist"
+    )
     try:
         report = FoundationPlist.readPlist(reportfile)
     except FoundationPlist.NSPropertyListSerializationException:
@@ -96,41 +99,48 @@ def readreport():
 def _warn(msg):
     """We can't use display module functions here because that would require
     circular imports. So a partial reimplementation."""
-    warning = 'WARNING: %s' % msg
-    print >> sys.stderr, warning.encode('UTF-8')
+    warning = "WARNING: %s" % msg
+    print >> sys.stderr, warning.encode("UTF-8")
     munkilog.log(warning)
     # append this warning to our warnings log
-    munkilog.log(warning, 'warnings.log')
+    munkilog.log(warning, "warnings.log")
 
 
 def archive_report():
     """Archive a report"""
     reportfile = os.path.join(
-        prefs.pref('ManagedInstallDir'), 'ManagedInstallReport.plist')
+        prefs.pref("ManagedInstallDir"), "ManagedInstallReport.plist"
+    )
     if os.path.exists(reportfile):
         modtime = os.stat(reportfile).st_mtime
-        formatstr = '%Y-%m-%d-%H%M%S'
-        archivename = ('ManagedInstallReport-%s.plist'
-                       % time.strftime(formatstr, time.localtime(modtime)))
-        archivepath = os.path.join(prefs.pref('ManagedInstallDir'), 'Archives')
+        formatstr = "%Y-%m-%d-%H%M%S"
+        archivename = "ManagedInstallReport-%s.plist" % time.strftime(
+            formatstr, time.localtime(modtime)
+        )
+        archivepath = os.path.join(prefs.pref("ManagedInstallDir"), "Archives")
         if not os.path.exists(archivepath):
             try:
                 os.mkdir(archivepath)
             except (OSError, IOError):
-                _warn('Could not create report archive path.')
+                _warn("Could not create report archive path.")
         try:
             os.rename(reportfile, os.path.join(archivepath, archivename))
         except (OSError, IOError):
-            _warn('Could not archive report.')
+            _warn("Could not archive report.")
         # now keep number of archived reports to 100 or fewer
-        proc = subprocess.Popen(['/bin/ls', '-t1', archivepath],
-                                bufsize=1, stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
+        proc = subprocess.Popen(
+            ["/bin/ls", "-t1", archivepath],
+            bufsize=1,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
         (output, dummy_err) = proc.communicate()
         if output:
-            archiveitems = [item
-                            for item in str(output).splitlines()
-                            if item.startswith('ManagedInstallReport-')]
+            archiveitems = [
+                item
+                for item in str(output).splitlines()
+                if item.startswith("ManagedInstallReport-")
+            ]
             if len(archiveitems) > 100:
                 for item in archiveitems[100:]:
                     itempath = os.path.join(archivepath, item)
@@ -138,7 +148,7 @@ def archive_report():
                         try:
                             os.unlink(itempath)
                         except (OSError, IOError):
-                            _warn('Could not remove archive item %s' % item)
+                            _warn("Could not remove archive item %s" % item)
 
 
 # module globals
@@ -147,5 +157,5 @@ report = {}
 # pylint: enable=invalid-name
 
 
-if __name__ == '__main__':
-    print 'This is a library of support tools for the Munki Suite.'
+if __name__ == "__main__":
+    print "This is a library of support tools for the Munki Suite."

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/utils.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/utils.py
@@ -31,8 +31,9 @@ import stat
 
 
 class Memoize(dict):
-    '''Class to cache the return values of an expensive function.
-    This version supports only functions with non-keyword arguments'''
+    """Class to cache the return values of an expensive function.
+    This version supports only functions with non-keyword arguments"""
+
     def __init__(self, func):
         self.func = func
 
@@ -68,6 +69,7 @@ class InsecureFilePermissionsError(VerifyFilePermissionsError):
 # so disable PyLint warnings about invalid function names
 # pylint: disable=C0103
 
+
 def verifyFileOnlyWritableByMunkiAndRoot(file_path):
     """
     Check the permissions on a given file path; fail if owner or group
@@ -85,27 +87,27 @@ def verifyFileOnlyWritableByMunkiAndRoot(file_path):
         file_stat = os.stat(file_path)
     except OSError, err:
         raise VerifyFilePermissionsError(
-            '%s does not exist. \n %s' % (file_path, str(err)))
+            "%s does not exist. \n %s" % (file_path, str(err))
+        )
 
     try:
-        admin_gid = grp.getgrnam('admin').gr_gid
-        wheel_gid = grp.getgrnam('wheel').gr_gid
+        admin_gid = grp.getgrnam("admin").gr_gid
+        wheel_gid = grp.getgrnam("wheel").gr_gid
         user_gid = os.getegid()
         # verify the munki process uid matches the file owner uid.
         if os.geteuid() != file_stat.st_uid:
-            raise InsecureFilePermissionsError(
-                'owner does not match munki process!')
+            raise InsecureFilePermissionsError("owner does not match munki process!")
         # verify the munki process gid matches the file owner gid, or the file
         # owner gid is wheel or admin gid.
         elif file_stat.st_gid not in [admin_gid, wheel_gid, user_gid]:
-            raise InsecureFilePermissionsError(
-                'group does not match munki process!')
+            raise InsecureFilePermissionsError("group does not match munki process!")
         # verify other users cannot write to the file.
         elif file_stat.st_mode & stat.S_IWOTH != 0:
-            raise InsecureFilePermissionsError('world writable!')
+            raise InsecureFilePermissionsError("world writable!")
     except InsecureFilePermissionsError, err:
         raise InsecureFilePermissionsError(
-            '%s is not secure! %s' % (file_path, err.args[0]))
+            "%s is not secure! %s" % (file_path, err.args[0])
+        )
 
 
 def runExternalScript(script, allow_insecure=False, script_args=()):
@@ -122,14 +124,16 @@ def runExternalScript(script, allow_insecure=False, script_args=()):
       RunExternalScriptError: there was an error running the script.
     """
     if not os.path.exists(script):
-        raise ScriptNotFoundError('script does not exist: %s' % script)
+        raise ScriptNotFoundError("script does not exist: %s" % script)
 
     if not allow_insecure:
         try:
             verifyFileOnlyWritableByMunkiAndRoot(script)
         except VerifyFilePermissionsError, err:
-            msg = ('Skipping execution due to failed file permissions '
-                   'verification: %s\n%s' % (script, str(err)))
+            msg = (
+                "Skipping execution due to failed file permissions "
+                "verification: %s\n%s" % (script, str(err))
+            )
             raise RunExternalScriptError(msg)
 
     if os.access(script, os.X_OK):
@@ -138,36 +142,48 @@ def runExternalScript(script, allow_insecure=False, script_args=()):
             cmd.extend(script_args)
         proc = None
         try:
-            proc = subprocess.Popen(cmd, shell=False,
-                                    stdin=subprocess.PIPE,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE)
+            proc = subprocess.Popen(
+                cmd,
+                shell=False,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
         except (OSError, IOError), err:
             raise RunExternalScriptError(
-                'Error %s when attempting to run %s' % (unicode(err), script))
+                "Error %s when attempting to run %s" % (unicode(err), script)
+            )
         if proc:
             (stdout, stderr) = proc.communicate()
-            return proc.returncode, stdout.decode('UTF-8', 'replace'), \
-                                    stderr.decode('UTF-8', 'replace')
+            return (
+                proc.returncode,
+                stdout.decode("UTF-8", "replace"),
+                stderr.decode("UTF-8", "replace"),
+            )
     else:
-        raise RunExternalScriptError('%s not executable' % script)
+        raise RunExternalScriptError("%s not executable" % script)
 
 
 def getPIDforProcessName(processname):
-    '''Returns a process ID for processname'''
-    cmd = ['/bin/ps', '-eo', 'pid=,command=']
+    """Returns a process ID for processname"""
+    cmd = ["/bin/ps", "-eo", "pid=,command="]
     try:
-        proc = subprocess.Popen(cmd, shell=False, bufsize=-1,
-                                stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                                stderr=subprocess.STDOUT)
+        proc = subprocess.Popen(
+            cmd,
+            shell=False,
+            bufsize=-1,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
     except OSError:
         return 0
 
     while True:
-        line = proc.stdout.readline().decode('UTF-8')
+        line = proc.stdout.readline().decode("UTF-8")
         if not line and (proc.poll() != None):
             break
-        line = line.rstrip('\n')
+        line = line.rstrip("\n")
         if line:
             try:
                 (pid, process) = line.split(None, 1)
@@ -186,22 +202,22 @@ def getFirstPlist(textString):
     more text-style plists.
     Returns a tuple - the first plist (if any) and the remaining
     string after the plist"""
-    plist_header = '<?xml version'
-    plist_footer = '</plist>'
+    plist_header = "<?xml version"
+    plist_footer = "</plist>"
     plist_start_index = textString.find(plist_header)
     if plist_start_index == -1:
         # not found
         return ("", textString)
     plist_end_index = textString.find(
-        plist_footer, plist_start_index + len(plist_header))
+        plist_footer, plist_start_index + len(plist_header)
+    )
     if plist_end_index == -1:
         # not found
         return ("", textString)
     # adjust end value
     plist_end_index = plist_end_index + len(plist_footer)
-    return (textString[plist_start_index:plist_end_index],
-            textString[plist_end_index:])
+    return (textString[plist_start_index:plist_end_index], textString[plist_end_index:])
 
 
-if __name__ == '__main__':
-    print 'This is a library of support tools for the Munki Suite.'
+if __name__ == "__main__":
+    print "This is a library of support tools for the Munki Suite."

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/utils.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/utils.py
@@ -13,8 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-utils
+"""utils.
 
 Created by Justin McWilliams on 2010-10-26.
 
@@ -32,7 +31,9 @@ import stat
 
 class Memoize(dict):
     """Class to cache the return values of an expensive function.
-    This version supports only functions with non-keyword arguments"""
+
+    This version supports only functions with non-keyword arguments
+    """
 
     def __init__(self, func):
         self.func = func
@@ -71,9 +72,8 @@ class InsecureFilePermissionsError(VerifyFilePermissionsError):
 
 
 def verifyFileOnlyWritableByMunkiAndRoot(file_path):
-    """
-    Check the permissions on a given file path; fail if owner or group
-    does not match the munki process (default: root/admin) or the group is not
+    """Check the permissions on a given file path; fail if owner or group does
+    not match the munki process (default: root/admin) or the group is not
     'wheel', or if other users are able to write to the file. This prevents
     escalated execution of arbitrary code.
 
@@ -165,7 +165,7 @@ def runExternalScript(script, allow_insecure=False, script_args=()):
 
 
 def getPIDforProcessName(processname):
-    """Returns a process ID for processname"""
+    """Returns a process ID for processname."""
     cmd = ["/bin/ps", "-eo", "pid=,command="]
     try:
         proc = subprocess.Popen(
@@ -198,10 +198,12 @@ def getPIDforProcessName(processname):
 
 
 def getFirstPlist(textString):
-    """Gets the next plist from a text string that may contain one or
-    more text-style plists.
+    """Gets the next plist from a text string that may contain one or more
+    text-style plists.
+
     Returns a tuple - the first plist (if any) and the remaining
-    string after the plist"""
+    string after the plist
+    """
     plist_header = "<?xml version"
     plist_footer = "</plist>"
     plist_start_index = textString.find(plist_header)


### PR DESCRIPTION
(Replaces #1253.)

This change would implement a [Pre-Commit](https://pre-commit.com) configuration that prevents contributors from committing unless certain basic tests pass. As configured here, the tests include:

- [Black](https://black.readthedocs.io/en/stable/) formatting for Python files
- All PHP files pass `php -l` linting check
- No added files exceed 100KB
- No leftover merge conflicts within files
- UNIX style line endings only

Additional hooks have been included in the config file but remain commented out, because they will require a bit more work to initially implement. These future tests could include:

- Eliminating unnecessary trailing whitespace
- Standardizing file endings
- YAML syntax checking (which would catch issues like the one fixed in #1252)
- Verifying executable shebangs

Many other [pre-commit hooks](https://pre-commit.com/hooks.html) are available, some of which may also be useful and can be added later if the maintainers find them useful.

In order to use pre-commit, each contributor would need to [install pre-commit](https://pre-commit.com/#install), then run `pre-commit install` to activate the hooks. A similar system is now in use for the [AutoPkg project](https://github.com/autopkg/autopkg/blob/master/CONTRIBUTING.md#use-pre-commit-to-set-automatic-commit-requirements).

Thanks for considering!