### PR TITLE
Adding python/json installer/file types for module template

### DIFF
--- a/build/templates/module/py-install.stub
+++ b/build/templates/module/py-install.stub
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# MODULE controller
+CTL="${BASEURL}index.php?/module/MODULE/"
+
+# Get the scripts in the proper directories
+"${CURL[@]}" "${CTL}get_script/MODULE.py" -o "${MUNKIPATH}preflight.d/MODULE.py"
+
+# Check exit status of curl
+if [ $? = 0 ]; then
+	# Make executable
+	chmod a+x "${MUNKIPATH}preflight.d/MODULE.py"
+
+	# Set preference to include this file in the preflight check
+	setreportpref "MODULE" "${CACHEPATH}MODULE.json"
+
+else
+	echo "Failed to download all required components!"
+	rm -f "${MUNKIPATH}preflight.d/MODULE.py"
+
+	# Signal that we had an error
+	ERR=1
+fi

--- a/build/templates/module/py-module_script.stub
+++ b/build/templates/module/py-module_script.stub
@@ -1,0 +1,40 @@
+#!/usr/bin/python
+
+import subprocess
+import os
+import sys
+import json
+sys.path.insert(0, '/usr/local/munki')
+sys.path.insert(0, '/usr/local/munkireport')
+from Foundation import CFPreferencesCopyAppValue
+from munkilib import FoundationPlist
+
+def get_pref_value(key, domain):
+    value = CFPreferencesCopyAppValue(key, domain)
+    if(value is not None):
+        return value
+    elif(value is not None and len(value) == 0):
+        return ""
+    else:
+        return ""
+
+def main():
+    """Main"""
+    # Create cache dir if it does not exist
+    cachedir = '%s/cache' % os.path.dirname(os.path.realpath(__file__))
+    if not os.path.exists(cachedir):
+        os.makedirs(cachedir)
+
+    data = {}
+
+    # Business logic goes here
+    # Add things to data dictionary
+    LOGIC
+
+    # Write memory results to cache
+    output_file = os.path.join(cachedir, 'MODULE.json')
+    with open(output_file, 'w') as fp:
+        json.dump(data, fp, indent=4, sort_keys=True)
+
+if __name__ == "__main__":
+    main()

--- a/build/templates/module/py-processor.stub
+++ b/build/templates/module/py-processor.stub
@@ -1,0 +1,24 @@
+<?php
+
+use munkireport\processors\Processor;
+
+class CLASS_processor extends Processor
+{
+    public function run($json)
+    {
+        // Check if data was uploaded
+        if (! $json ) {
+            throw new Exception("Error Processing Request: No JSON file found", 1);
+        }
+        // Process json into object thingy
+        $data = json_decode($json, true);
+        $data['serial_number'] = $this->serial_number;
+
+        CLASS_model::updateOrCreate(
+			['serial_number' => $this->serial_number],
+            $data
+        );
+        
+        return $this;
+    }   
+}

--- a/build/templates/module/py-uninstall.stub
+++ b/build/templates/module/py-uninstall.stub
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Remove MODULE script
+rm -f "${MUNKIPATH}preflight.d/MODULE.py"
+
+# Remove MODULE.txt file
+rm -f "${MUNKIPATH}preflight.d/cache/MODULE.json"


### PR DESCRIPTION
I'd like to add an option for `please make:module` to use python vs bash, so consider this a feature request as well 😅 . I gathered how to do the `.stub` files, but have not dug into the actual template. Not sure if it's possible to give the user the choice, but I think that would be ideal.