### PR TITLE
Use env variable "SYSTEM_VERSION_COMPAT" and shell for OS detection

### DIFF
--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/reportcommon.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/reportcommon.py
@@ -550,7 +550,19 @@ def getOsVersion(only_major_minor=True, as_tuple=False):
       only_major_minor: Boolean. If True, only include major/minor versions.
       as_tuple: Boolean. If True, return a tuple of ints, otherwise a string.
     """
-    os_version_tuple = platform.mac_ver()[0].split(".")
+    os.environ["SYSTEM_VERSION_COMPAT"] = '0'
+    cmd = ["/usr/bin/sw_vers -productVersion"]
+    proc = subprocess.Popen(
+        cmd,
+        shell=True,
+        bufsize=-1,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    (output, unused_error) = proc.communicate()
+    output = output.strip()
+    os_version_tuple = output.split(".")
     if only_major_minor:
         os_version_tuple = os_version_tuple[0:2]
     if as_tuple:


### PR DESCRIPTION
Big Sur reports its OS version as 10.16 or 11.x depending on which SDK the calling mechanism is compiled against.  There is an environment variable "SYSTEM_VERSION_COMPAT" that can be used to make the output more predictable.

The built in Python shipped with BigSur hard codes the variable so all Big Sur installs are reporting as 10.16.0.
Furthermore, 10.16.0 is a frozen version of the OS regardless of updates.  Any machine reporting as 10.16.0 will always only report as 10.16.0 even if the real OS version is 11.2.3, etc.  

This PR is to consider changing how the OS is detected to shell out and use the environment variable to report the actual OS version instead of the compatibility-mode version.

This was tested against 10.12-11.0.1 systems. All are reporting properly without error.

-Eric