### PR TITLE
add auth based on server env var

### DIFF
--- a/app/config/auth/env.php
+++ b/app/config/auth/env.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'env_user_var'            => 'REMOTE_USER',
+];

--- a/app/helpers/config_helper.php
+++ b/app/helpers/config_helper.php
@@ -30,6 +30,9 @@ function loadAuthConfig()
             case 'NOAUTH':
                 $auth_config['auth_noauth'] = require APP_ROOT . 'app/config/auth/noauth.php';
                 break;
+            case 'ENV':
+                $auth_config['auth_env'] = require APP_ROOT . 'app/config/auth/env.php';
+                break;
             case 'SAML':
                 $auth_config['auth_saml'] = require APP_ROOT . 'app/config/auth/saml.php';
                 break;

--- a/app/lib/munkireport/AuthEnv.php
+++ b/app/lib/munkireport/AuthEnv.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace munkireport\lib;
+
+class AuthEnv extends AbstractAuth
+{
+    private $config;
+
+    public function __construct($config)
+    {
+        $this->config = $config;
+    }
+    
+    public function login($login, $password)
+    {
+        return true;
+    }
+    
+    public function getAuthMechanism()
+    {
+        return 'env';
+    }
+
+    public function getAuthStatus()
+    {
+        return 'success';
+    }
+    
+    public function getUser()
+    {
+        return getenv($this->config['env_user_var']);
+    }
+
+    public function getGroups()
+    {
+        return [];
+    }
+}

--- a/app/lib/munkireport/AuthHandler.php
+++ b/app/lib/munkireport/AuthHandler.php
@@ -10,6 +10,7 @@ class AuthHandler
     // Authentication mechanisms we handle => classname
     private $mechanisms = [
         'noauth' => 'AuthNoauth',
+        'env' => 'AuthEnv',
         'local' => 'AuthLocal',
         'ldap' => 'AuthLDAP',
         'AD' => 'AuthAD',

--- a/app/views/partials/head.php
+++ b/app/views/partials/head.php
@@ -245,7 +245,7 @@
 						</ul>
 				</li>
 
-				<?php if( ! array_key_exists('auth_noauth', conf('auth'))): // Hide logout button if auth_noauth?>
+				<?php if( ! array_key_exists('auth_noauth', conf('auth'))): // Hide user menu if auth_noauth?>
 
 				<li class="dropdown">
 					<a href="#" class="dropdown-toggle" data-toggle="dropdown">
@@ -253,12 +253,14 @@
 						<b class="caret"></b>
 					</a>
 					<ul class="dropdown-menu">
+					<?php if( ! array_key_exists('auth_env', conf('auth'))): // Hide logout menu item if auth_env?>
 						<li>
 							<a href="<?php echo url('auth/logout'); ?>">
 								<i class="fa fa-power-off"></i>
 								<span data-i18n="nav.user.logout"></span>
 							</a>
 						</li>
+					<?php endif; ?>
 					</ul>
 				</li>
 


### PR DESCRIPTION
Adds auth mechanism `ENV` that is based on an environment variable set by a server

This allows MunkiReport's auth to be configured in alignment with standard auth mechanisms available in some HTTP servers, like e.g. Apache HTTPd.  With auth set to `ENV`, MunkiReport knows that it has to look for a value of an environment variable to determine the name of the user logged in.  The name of the environment variable is configurable, set to `REMOTE_USER` by default.