### PR TITLE
Update PHPass dependency to new maintainer until we know impact.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "guzzlehttp/guzzle": "^6.3.1|^7.0.1",
         "laravel/framework": "^7.29",
         "laravel/tinker": "^2.5",
-        "hautelook/phpass": "^1.1",
+        "bordoni/phpass": "^0.3",
         "rodneyrehm/plist": "^2.0",
         "defuse/php-encryption": "^2.1",
         "munkireport/ard": "^3.0",


### PR DESCRIPTION
Similar to Sphens PR, just to get tests passing again