### PR TITLE
python3 compatibility in purl/reportcommon

### DIFF
--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/purl.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/purl.py
@@ -134,7 +134,7 @@ class Purl(NSObject):
         if options.get("content_type") is not None:
             self.additional_headers["Content-Type"] = options.get("content_type")
         self.body = options.get("body")
-        self.response_data = ""
+        self.response_data = b''
 
         self.log = options.get("logging_function", NSLog)
 
@@ -420,4 +420,4 @@ class Purl(NSObject):
 
         # we don't actually use the connection argument, so
         # pylint: disable=W0613
-        self.response_data = self.response_data + str(data)
+        self.response_data = self.response_data + data

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/reportcommon.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/reportcommon.py
@@ -326,7 +326,7 @@ def process(serial, items):
 
     # Decode response
     try:
-        result = unserialize(server_data)
+        result = unserialize(server_data.decode('utf8'))
     except Exception as e:
         display_error("Could not unserialize server data: %s" % str(e))
         display_error("Request: %s" % str(values))

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkireport-runner
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkireport-runner
@@ -1,6 +1,6 @@
 #!/usr/local/munkireport/python3
 # encoding: utf-8
-'''Postflight script'''
+"""Postflight script"""
 
 from munkilib import reportcommon
 from munkilib import FoundationPlist
@@ -8,8 +8,9 @@ import hashlib
 import sys
 import os
 
+
 def main():
-    '''Main'''
+    """Main"""
 
     reportcommon.display_detail("## Starting MunkiReport run")
 
@@ -60,6 +61,7 @@ def main():
 
     reportcommon.process(serial, items)
     reportcommon.finish_run()
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Update purl.py to store response as "data" aka bytes not str(), which solves an issue when purl tries to convert every chunk in the response to str() and ends up double encoding the response data.

Update reportcommon.py to decode the bytes returned by Purl
Minor PEP code style changes.