### PR TITLE
Hotfix/safe unserializer

### DIFF
--- a/app/Http/Controllers/Client/InventoryController.php
+++ b/app/Http/Controllers/Client/InventoryController.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Client;
 
+use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use munkireport\lib\Unserializer;
 
-class ReportsController extends Controller
+class InventoryController extends Controller
 {
     /**
      * Process MunkiReport Checkins using the \App\Reports class.

--- a/app/Http/Controllers/Client/InventoryController.php
+++ b/app/Http/Controllers/Client/InventoryController.php
@@ -4,7 +4,9 @@ namespace App\Http\Controllers\Client;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
-use munkireport\lib\Unserializer;
+use Illuminate\Support\Facades\Log;
+use function xKerman\Restricted\unserialize;
+use xKerman\Restricted\UnserializeFailedException;
 
 class InventoryController extends Controller
 {
@@ -26,10 +28,10 @@ class InventoryController extends Controller
 
         $reports = app(\App\Reports::class);
         try{
-            $unserializer = new Unserializer($validatedData['items']);
-            $arr = $unserializer->unserialize();
+            $arr = unserialize($request->get('items'));
         }
-        catch (\Exception $e){
+        catch (Exception $e){
+            Log::error($e);
             return response(serialize(array('error' => 'Could not unserialize items')));
         }
 

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -17,6 +17,13 @@ class RouteServiceProvider extends ServiceProvider
     protected $namespace = 'App\Http\Controllers';
 
     /**
+     * This namespace is used for routes that are serving endpoints to the report runner client.
+     *
+     * @var string
+     */
+    protected $clientNamespace = 'App\Http\Controllers\Client';
+
+    /**
      * The path to the "home" route for your application.
      *
      * @var string
@@ -120,7 +127,7 @@ class RouteServiceProvider extends ServiceProvider
     protected function mapClientRoutes()
     {
         Route::middleware('client.passphrase')
-            ->namespace($this->namespace)
+            ->namespace($this->clientNamespace)
             ->group(base_path('routes/client.php'));
     }
 }

--- a/app/lib/munkireport/Unserializer.php
+++ b/app/lib/munkireport/Unserializer.php
@@ -2,6 +2,8 @@
 
 namespace munkireport\lib;
 
+use Illuminate\Support\Facades\Log;
+
 /**
  * Replacement for unserialize
  *
@@ -18,6 +20,7 @@ class Unserializer
     {
         $this->position = 0;
         $this->str = $s;
+        Log::warning("The munkireport Unserializer will be deprecated. Please refactor as soon as possible to use xkerman/restricted-unserialize");
     }
 
     public function await($symbol, $n = 1)

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/phpserialize.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/phpserialize.py
@@ -158,11 +158,15 @@ def serialize(struct, typecast=None):
         return "i:%d;" % struct
 
     # s:<string_length>:"<string>";
-    if struct_type is str:
-        return 's:%d:"%s";' % (len(struct), struct)
+    # NOTE: This will return an incorrect length in Python 3 if the string contains Unicode characters
+    # because len(str(bytes)) isnt the same as len(bytes).
+    # if struct_type is str:
+    #     return 's:%d:"%s";' % (len(struct), struct)
 
+    # Serializing string types recursively wont work because the length will change before/after utf-8 encoding
     if struct_type is str:
-        return serialize(struct.encode("utf-8"), typecast)
+        return 's:%d:"%s";' % (len(struct.encode("utf-8")), struct)
+        #return serialize(struct.encode("utf-8"), typecast)
 
     # Assume python 3 byte encoded string
     if struct_type is bytes:

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/reportcommon.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/reportcommon.py
@@ -326,19 +326,19 @@ def process(serial, items):
 
     # Decode response
     try:
-        result = unserialize(server_data.decode('utf8'))
+        result = unserialize(server_data.decode('utf-8'))
     except Exception as e:
         display_error("Could not unserialize server data: %s" % str(e))
-        display_error("Request: ", str(values))
-        display_error("Response: ", str(server_data))
+        display_error("Request: %s", str(values))
+        display_error("Response: %s", str(server_data))
         return -1
 
     if result.get("error") != "":
-        display_error("Server error: ", result["error"])
+        display_error("Server error: %s", result["error"])
         return -1
 
     if result.get("info") != "":
-        display_detail("Server info: ", result['info'])
+        display_detail("Server info: %s", result['info'])
 
     # Retrieve hashes that need updating
     total_size = 0

--- a/public/assets/client_installer/payload/usr/local/munkireport/munkilib/reportcommon.py
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkilib/reportcommon.py
@@ -329,16 +329,16 @@ def process(serial, items):
         result = unserialize(server_data.decode('utf8'))
     except Exception as e:
         display_error("Could not unserialize server data: %s" % str(e))
-        display_error("Request: %s" % str(values))
-        display_error("Response: %s" % str(server_data))
+        display_error("Request: ", str(values))
+        display_error("Response: ", str(server_data))
         return -1
 
     if result.get("error") != "":
-        display_error("Server error: %s" % result["error"])
+        display_error("Server error: ", result["error"])
         return -1
 
     if result.get("info") != "":
-        display_detail("Server info: %s" % result["info"])
+        display_detail("Server info: ", result['info'])
 
     # Retrieve hashes that need updating
     total_size = 0

--- a/resources/views/install/install.blade.php
+++ b/resources/views/install/install.blade.php
@@ -14,6 +14,14 @@ REPORT_BROKEN_CLIENT_SCRIPT="{{ config('_munkireport.report_broken_client_script
 # Exit status
 ERR=0
 
+# Determine best usable python3 (ripped from outset - thanks chilcote).
+MRPHP_PYTHON="${MUNKIPATH}/python3"
+ORG_PYTHON=/usr/local/bin/python3
+MACADMINS_PYTHON=/usr/local/bin/managed_python3
+MUNKI_MUNKI_PYTHON=/usr/local/munki/munki-python
+MUNKI_PYTHON=/usr/local/munki/python
+SYSTEM_PYTHON=/usr/bin/python3
+
 # Packaging
 BUILDPKG=0
 IDENTIFIER="com.github.munkireport"
@@ -173,6 +181,26 @@ fi
 chmod a+x "${INSTALLROOT}/usr/local/munki/"{${POSTFLIGHT_SCRIPT},${REPORT_BROKEN_CLIENT_SCRIPT}}
 chmod a+x "${INSTALLROOT}/usr/local/munkireport/munkireport-runner"
 
+# Symlink best available Python3
+# Delete existing symlink
+[[ -L "${MRPHP_PYTHON}" ]] && /bin/rm "${MRPHP_PYTHON}"
+
+if [[ -L "${MACADMINS_PYTHON}" ]]; then
+    echo "Using Python 3.x installation at ${MACADMINS_PYTHON}"
+    /bin/ln -s "${MACADMINS_PYTHON}" "${MRPHP_PYTHON}"
+elif [[ -L "${MUNKI_MUNKI_PYTHON}" ]]; then
+    echo "Using Python 3.x installation at ${MUNKI_MUNKI_PYTHON}"
+    /bin/ln -s "${MUNKI_MUNKI_PYTHON}" "${MRPHP_PYTHON}"
+elif [[ -L "${MUNKI_PYTHON}" ]]; then
+    echo "Using Python 3.x installation at ${MUNKI_PYTHON}"
+    /bin/ln -s "${MUNKI_PYTHON}" "${MRPHP_PYTHON}"
+elif [[ -L "${ORG_PYTHON}" ]]; then
+    echo "Using Python 3.x installation at ${ORG_PYTHON}, If you do not have PyObjC installed, you will need to install it."
+    /bin/ln -s "${ORG_PYTHON}" "${MRPHP_PYTHON}"
+else
+    echo "Using Python 3.x installation at ${SYSTEM_PYTHON}, It is recommended to distribute MacAdmins python or python.org packages"
+    /bin/ln -s "${SYSTEM_PYTHON}" "${MRPHP_PYTHON}"
+fi
 
 echo "Configuring munkireport"
 #### Configure Munkireport ####

--- a/resources/views/install/install_script.php
+++ b/resources/views/install/install_script.php
@@ -185,10 +185,7 @@ chmod a+x "${INSTALLROOT}/usr/local/munkireport/munkireport-runner"
 # Delete existing symlink
 [[ -L "${MRPHP_PYTHON}" ]] && /bin/rm "${MRPHP_PYTHON}"
 
-if [[ -L "${ORG_PYTHON}" ]]; then
-    echo "Using Python 3.x installation at ${ORG_PYTHON}"
-    /bin/ln -s "${ORG_PYTHON}" "${MRPHP_PYTHON}"
-elif [[ -L "${MACADMINS_PYTHON}" ]]; then
+if [[ -L "${MACADMINS_PYTHON}" ]]; then
     echo "Using Python 3.x installation at ${MACADMINS_PYTHON}"
     /bin/ln -s "${MACADMINS_PYTHON}" "${MRPHP_PYTHON}"
 elif [[ -L "${MUNKI_MUNKI_PYTHON}" ]]; then
@@ -197,6 +194,9 @@ elif [[ -L "${MUNKI_MUNKI_PYTHON}" ]]; then
 elif [[ -L "${MUNKI_PYTHON}" ]]; then
     echo "Using Python 3.x installation at ${MUNKI_PYTHON}"
     /bin/ln -s "${MUNKI_PYTHON}" "${MRPHP_PYTHON}"
+elif [[ -L "${ORG_PYTHON}" ]]; then
+    echo "Using Python 3.x installation at ${ORG_PYTHON}, If you do not have PyObjC installed, you will need to install it."
+    /bin/ln -s "${ORG_PYTHON}" "${MRPHP_PYTHON}"
 else
     echo "Using Python 3.x installation at ${SYSTEM_PYTHON}, It is recommended to distribute MacAdmins python or python.org packages"
     /bin/ln -s "${SYSTEM_PYTHON}" "${MRPHP_PYTHON}"


### PR DESCRIPTION
Use an upstream safe php unserializer for submitted inventory data.
Adjust mr client phpserialize.py so it does not report the length of a string AFTER encoding, which fixes a bug that came up in python3 only.
Move some client parts to a Client directory.