### PR TITLE
Global search merge from scout branch (alpha)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ node_modules
 .phpunit.result.cache
 storage/oauth-private.key
 storage/oauth-public.key
+storage/*.index

--- a/MR/Kiss/Core/View.php
+++ b/MR/Kiss/Core/View.php
@@ -85,7 +85,37 @@ abstract class View
 
     }
 
-    public function fetch($vars = '')
+    /**
+     * Capture the output buffer from a view render instead of outputting it.
+     *
+     * NOTE: Be careful when the rendered `.php` file includes headers because the whole
+     * request may fail if the headers are rendered after some other content.
+     *
+     * @param string $file The file name, relative to the view path.
+     * @param array|null $vars The variables to substitute into the view.
+     * @param string $view_path The base path of all template file names given.
+     * @return string
+     */
+    public function viewFetch(string $file, array $vars = null, string $view_path = ''): string
+    {
+        //Bluebus addition
+        if(empty($view_path)){
+            $view_path = conf('view_path');
+        }
+
+        if (is_array($vars)) {
+            $this->vars=array_merge($this->vars, $vars);
+        }
+        extract($this->vars);
+
+        ob_start();
+        if (! @include($view_path.$file.'.php')) {
+            echo '<!-- Could not open '.$view_path.$file.'.php -->';
+        }
+        return ob_get_clean();
+    }
+
+    public function fetch($vars = ''): string
     {
         if (is_array($vars)) {
             $this->vars=array_merge($this->vars, $vars);

--- a/app/Http/Controllers/Api/SearchController.php
+++ b/app/Http/Controllers/Api/SearchController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Machine;
+use App\ReportData;
+use Illuminate\Http\Request;
+
+class SearchController extends Controller
+{
+    /**
+     * Free-text search a specific Eloquent Model.
+     *
+     * The model must use the Searchable trait to be searchable, and the model must
+     * already be indexed (via CLI or via API).
+     *
+     * @param string $model
+     * @param string $query
+     */
+    public function searchModel(string $model, string $query) {
+        $searchResults = [];
+
+        // This seemingly insane switch block is to prevent arbitrary access to models with passwords
+        switch ($model) {
+            case 'Machine':
+                $searchResults = Machine::search($query)->get();
+                break;
+            case 'ReportData':
+                $searchResults = ReportData::search($query)->get();
+                break;
+        }
+
+        return $searchResults;
+    }
+}

--- a/app/Machine.php
+++ b/app/Machine.php
@@ -7,10 +7,13 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use MR\Scopes\CreatedSinceScope;
 use munkireport\models\MRModel;
+use Laravel\Scout\Searchable;
 
 class Machine extends MRModel
 {
     use HasFactory;
+
+    use Searchable;
 
     protected $table = 'machine';
 

--- a/app/ReportData.php
+++ b/app/ReportData.php
@@ -9,10 +9,13 @@ use App\Scopes\UpdatedBetweenScope;
 use App\Scopes\UpdatedSinceScope;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use munkireport\models\MRModel;
+use Laravel\Scout\Searchable;
 
 class ReportData extends MRModel
 {
     use HasFactory;
+
+    use Searchable;
 
     /**
      * @inheritDoc

--- a/config/_munkireport.php
+++ b/config/_munkireport.php
@@ -467,6 +467,8 @@ return [
     */
     'alpha_features' => [
         // Enable the Alpha Vue Dashboards
-        'dashboards' => env('ALPHA_FEATURE_DASHBOARDS', False)
+        'dashboards' => env('ALPHA_FEATURE_DASHBOARDS', False),
+        // Enable the Global Search via Scout+TNTSearch
+        'search' => env('ALPHA_FEATURE_SEARCH', False),
     ]
 ];

--- a/config/app.php
+++ b/config/app.php
@@ -171,6 +171,8 @@ return [
         Adldap\Laravel\AdldapServiceProvider::class,
         Adldap\Laravel\AdldapAuthServiceProvider::class,
         Anhskohbo\NoCaptcha\NoCaptchaServiceProvider::class,
+        Laravel\Scout\ScoutServiceProvider::class,
+        TeamTNT\Scout\TNTSearchScoutServiceProvider::class,
 
         /*
          * Application Service Providers...

--- a/config/scout.php
+++ b/config/scout.php
@@ -1,0 +1,136 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Search Engine
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default search connection that gets used while
+    | using Laravel Scout. This connection is used when syncing all models
+    | to the search service. You should adjust this based on your needs.
+    |
+    | Supported: "algolia", "null"
+    |
+    */
+
+    'driver' => env('SCOUT_DRIVER', 'tntsearch'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Index Prefix
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify a prefix that will be applied to all search index
+    | names used by Scout. This prefix may be useful if you have multiple
+    | "tenants" or applications sharing the same search infrastructure.
+    |
+    */
+
+    'prefix' => env('SCOUT_PREFIX', ''),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Queue Data Syncing
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to control if the operations that sync your data
+    | with your search engines are queued. When this is set to "true" then
+    | all automatic data syncing will get queued for better performance.
+    |
+    */
+
+    'queue' => env('SCOUT_QUEUE', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Database Transactions
+    |--------------------------------------------------------------------------
+    |
+    | This configuration option determines if your data will only be synced
+    | with your search indexes after every open database transaction has
+    | been committed, thus preventing any discarded data from syncing.
+    |
+    */
+
+    'after_commit' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Chunk Sizes
+    |--------------------------------------------------------------------------
+    |
+    | These options allow you to control the maximum chunk size when you are
+    | mass importing data into the search engine. This allows you to fine
+    | tune each of these chunk sizes based on the power of the servers.
+    |
+    */
+
+    'chunk' => [
+        'searchable' => 500,
+        'unsearchable' => 500,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Soft Deletes
+    |--------------------------------------------------------------------------
+    |
+    | This option allows to control whether to keep soft deleted records in
+    | the search indexes. Maintaining soft deleted records can be useful
+    | if your application still needs to search for the records later.
+    |
+    */
+
+    'soft_delete' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Identify User
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to control whether to notify the search engine
+    | of the user performing the search. This is sometimes useful if the
+    | engine supports any analytics based on this application's users.
+    |
+    | Supported engines: "algolia"
+    |
+    */
+
+    'identify' => env('SCOUT_IDENTIFY', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Algolia Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure your Algolia settings. Algolia is a cloud hosted
+    | search engine which works great with Scout out of the box. Just plug
+    | in your application ID and admin API key to get started searching.
+    |
+    */
+
+    'algolia' => [
+        'id' => env('ALGOLIA_APP_ID', ''),
+        'secret' => env('ALGOLIA_SECRET', ''),
+    ],
+
+    /*
+     | TNTSearch Configuration
+     */
+
+    'tntsearch' => [
+        'storage'  => storage_path(), //place where the index files will be stored
+        'fuzziness' => env('TNTSEARCH_FUZZINESS', false),
+        'fuzzy' => [
+            'prefix_length' => 2,
+            'max_expansions' => 50,
+            'distance' => 2
+        ],
+        'asYouType' => false,
+        'searchBoolean' => env('TNTSEARCH_BOOLEAN', false),
+        'maxDocs' => env('TNTSEARCH_MAX_DOCS', 500),
+    ],
+
+];

--- a/routes/api.php
+++ b/routes/api.php
@@ -35,4 +35,6 @@ Route::group(['prefix' => 'v6', 'namespace' => 'Api', 'middleware' => 'auth:sanc
     Route::apiResource('machine_groups', 'MachineGroupsController');
     Route::apiResource('users', 'UsersController');
     Route::apiResource('users.contact_methods', 'UsersContactMethodsController');
+
+    Route::get('/search/{model}/{query}', 'SearchController@searchModel')->where('query', '.*');
 });

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -46,7 +46,11 @@ mix.copy('node_modules/datatables.net-buttons-bs4/js/buttons.bootstrap4.min.js',
 // munkireport originally used the typeahead.bundle.min file
 mix.copy('node_modules/typeahead.js/dist/typeahead.bundle.min.js', 'public/assets/js/typeahead.bundle.min.js');
 
+// Added for v6 - Bootstrap 4 Autocomplete for Search Bar
+mix.copy('node_modules/bootstrap-4-autocomplete/dist/bootstrap-4-autocomplete.min.js', 'public/js/bootstrap-4-autocomplete.min.js');
+
 // Mix ALL MunkiReport 5.x dependencies to reduce number of individual connections
+// This should replace everything above, but needs some testing.
 mix.scripts([
   'node_modules/jquery/dist/jquery.min.js',
   'node_modules/popper.js/dist/umd/popper.min.js',
@@ -63,10 +67,14 @@ mix.scripts([
 ], 'public/js/all.js');
 
 
+// For routes which are completely Single-Page App (Completely controlled by VueJS)
 mix.js('resources/js/app.js', 'public/js')
   .extract(['jquery', 'popper.js', 'bootstrap', 'lodash', 'i18next', 'axios', 'vue', 'vue-router', 'vue-i18next', 'vue-grid-layout'])
   .sass('resources/sass/app.scss', 'public/css')
   .vue();
+
+// For routes which still have jQuery, but want to use Vue components
+mix.js('resources/js/mixed-app.js', 'public/js');
 
 // mix.js('resources/js/business-units.js', 'public/js');
 // mix.js('resources/js/profile.js', 'public/js');


### PR DESCRIPTION
Add SearchController for submitting searches for each model type.
Make Machine and ReportData searchable
Put search feature behind a feature flag `ALPHA_FEATURE_SEARCH`.
Add Laravel Scout and the TNT Search Provider as a lazy option
Add Laravel Scout Default Config
Add search routes
Ignore TNTSearch index in .gitignore