### PR TITLE
Remove more legacy code

### DIFF
--- a/app/Http/Controllers/Client/ReportController.php
+++ b/app/Http/Controllers/Client/ReportController.php
@@ -436,7 +436,7 @@ class ReportController extends Controller
     {
         $mylist = [
             'machine_group' => $this->group,
-            'remote_ip' => getRemoteAddress(),
+            'remote_ip' => request()->getClientIp(),
             'timestamp' => time(),
             'archive_status' => 0, // Reset status
         ];

--- a/app/Http/Controllers/InstallController.php
+++ b/app/Http/Controllers/InstallController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Adapter\Local;
+use munkireport\lib\Modules;
 
 
 class InstallController extends Controller
@@ -13,7 +14,7 @@ class InstallController extends Controller
 
     public function __construct()
     {
-        $this->moduleManager = getMrModuleObj();
+        $this->moduleManager = app(Modules::class);
     }
 
     /**

--- a/app/Http/Controllers/LocaleController.php
+++ b/app/Http/Controllers/LocaleController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
+use munkireport\lib\Modules;
 
 class LocaleController extends Controller
 {
@@ -13,7 +14,7 @@ class LocaleController extends Controller
 
     public function __construct()
     {
-        $this->modules = getMrModuleObj()->loadInfo();
+        $this->modules = app(Modules::class)->loadInfo();
     }
 
     /**
@@ -29,7 +30,7 @@ class LocaleController extends Controller
     {
         // Check if we should load all modules' locales
         if($load == 'all_modules'){
-            $this->modules = getMrModuleObj()->loadInfo(True);
+            $this->modules = app(Modules::class)->loadInfo(True);
         }
 
 //        $locales = [

--- a/app/Http/Controllers/ManagerController.php
+++ b/app/Http/Controllers/ManagerController.php
@@ -9,6 +9,16 @@ use Illuminate\Support\Str;
 
 class ManagerController extends Controller
 {
+    /**
+     * Delete all records of the machine by the serial number given.
+     *
+     * The way this happens is not db agnostic at all, and might be prone to error.
+     * It is recommended to use foreign key constraints with a cascade delete to avoid using this particular action.
+     *
+     * @param string $serial_number
+     * @return \Illuminate\Http\JsonResponse|void
+     * @throws \Exception
+     */
     public function delete_machine(string $serial_number = '')
     {
         Gate::authorize('delete_machine');

--- a/app/Http/Controllers/ModuleController.php
+++ b/app/Http/Controllers/ModuleController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use munkireport\lib\Modules;
 
 class ModuleController extends Controller
 {
@@ -12,7 +13,7 @@ class ModuleController extends Controller
 
     public function __construct()
     {
-        $this->moduleManager = getMrModuleObj();
+        $this->moduleManager = app(Modules::class);
     }
 
     public function index()

--- a/app/Http/Controllers/ModuleMarketplaceController.php
+++ b/app/Http/Controllers/ModuleMarketplaceController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Str;
+use munkireport\lib\Modules;
 use munkireport\lib\Request;
 use munkireport\controller\Module_marketplace;
 use Symfony\Component\Yaml\Yaml;
@@ -15,7 +16,7 @@ class ModuleMarketplaceController extends Controller
     public function __construct()
     {
         // Create object
-        $this->moduleMarketplace = getMrModuleObj();
+        $this->moduleMarketplace = app(Modules::class);
     }
 
     /**

--- a/app/helpers/bootstrap_helper.php
+++ b/app/helpers/bootstrap_helper.php
@@ -4,6 +4,8 @@
  * Maintained here for backwards compatibility.
  */
 
+use Illuminate\Support\Facades\Log;
+
 /**
  * Check if Request is secure
  *
@@ -17,12 +19,21 @@ function SslRequest() {
 }
 
 /**
- * Get session item
+ * Get session item.
+ *
  * @param string session item
  * @param string default value (optional)
+ * @deprecated Use session() helper.
+ * @todo Still used in laps module, cannot be fully deprecated.
  * @author AvB
  **/
 function sess_get($sess_item, $default = '')
 {
+    Log::channel('deprecations')
+        ->warning('This function will be deprecated in future, please use session()->get() in your modules.', [
+            'function' => __FUNCTION__,
+            'file' => __FILE__,
+            'line' => __LINE__,
+        ]);
     return request()->session()->get($sess_item, $default);
 }

--- a/app/helpers/config_helper.php
+++ b/app/helpers/config_helper.php
@@ -1,36 +1,55 @@
 <?php
 
+use Illuminate\Support\Facades\Log;
+
 function initConfig()
 {
+    Log::channel('deprecations')
+        ->warning('This function will be deprecated in future, please use config() in your modules.', [
+            'function' => __FUNCTION__,
+            'file' => __FILE__,
+            'line' => __LINE__,
+        ]);
     $GLOBALS['conf'] = [];
 }
 
 /**
  * Add config array to global config array
  *
- *
  * @param array $configArray
+ * @deprecated Try to use package file publishing with modules, and then access config via config('module.setting')
  */
 function configAppendArray($configArray, $namespace = '')
 {
-	if($namespace){
-    $GLOBALS['conf'] += [$namespace => $configArray];
-  }
-  else{
-    $GLOBALS['conf'] += $configArray;
-  }
+    Log::channel('deprecations')
+        ->warning('This function will be deprecated in future, please use config() in your modules.', [
+            'function' => __FUNCTION__,
+            'file' => __FILE__,
+            'line' => __LINE__,
+        ]);
+    if ($namespace) {
+        $GLOBALS['conf'] += [$namespace => $configArray];
+    } else {
+        $GLOBALS['conf'] += $configArray;
+    }
 }
 
 /**
- * Add config file to global config array
- *
+ * Add config file to global config array.
  *
  * @param array $configPath
+ * @deprecated Try to use package file publishing with modules, and then access config via config('module.setting')
  */
 function configAppendFile($configPath, $namespace = '')
 {
-	$config = require $configPath;
-	configAppendArray($config, $namespace);
+    Log::channel('deprecations')
+        ->warning('This function will be deprecated in future, please use config() in your modules.', [
+            'function' => __FUNCTION__,
+            'file' => __FILE__,
+            'line' => __LINE__,
+        ]);
+    $config = require $configPath;
+    configAppendArray($config, $namespace);
 }
 
 /**
@@ -41,6 +60,7 @@ function configAppendFile($configPath, $namespace = '')
  * @param $cf_item
  * @param string $default
  * @return mixed|string
+ * @deprecated Use config('section.name', 'default')
  */
 function conf($cf_item, $default = '')
 {
@@ -88,7 +108,8 @@ function conf($cf_item, $default = '')
     }
 
     if (in_array($cf_item, [
-        'dashboard', 'widget'
+        'dashboard',
+        'widget'
     ])) {
         return config($cf_item);
     }
@@ -104,13 +125,24 @@ function conf($cf_item, $default = '')
     }
 }
 
-
-function local_conf($item)
+/**
+ * Get a path relative to the local configuration directory, usually <munkireport installation>/local.
+ *
+ * @param string $item The path relative to the local dir
+ * @return string The absolute path to the item given.
+ */
+function local_conf(string $item): string
 {
-    return rtrim(conf('local'), '/') . '/' . $item;
+    return rtrim(config('_munkireport.local'), '/') . '/' . $item;
 }
 
-function module_conf($item)
+/**
+ * Get a path relative to the local module configuration directory.
+ *
+ * @param string $item The path relative to the local module_configs dir.
+ * @return string The absolute path to the item given.
+ */
+function module_conf(string $item): string
 {
-    return local_conf('module_configs/' .$item);
+    return local_conf('module_configs/' . $item);
 }

--- a/app/helpers/env_helper.php
+++ b/app/helpers/env_helper.php
@@ -1,7 +1,19 @@
 <?php
-// Get a value from $_ENV with fallback to default
-// typehint parameter processes env var as the suggested type.
-function mr_env($key, $default = null, $typehint = null) {
+/**
+ * Get the value of an environment variable.
+ *
+ * This function, unlike the Laravel config() function, allows you to typehint the return value which might be casted
+ * to or converted from its string representation as an environment variable.
+ *
+ * @param string $key The environment variable to read
+ * @param mixed|Closure|null $default The default value to return if the environment variable is not found. Defaults to null.
+ *                                    You may supply a closure if required.
+ * @param mixed|null $typehint Type hint the return type to perform a cast or conversion. Valid type hints are one of
+ *                             'array','bool','boolean','int','integer'.
+ * @return array|bool|int|mixed|string|null The return value, optionally casted to the type hinted type.
+ * @deprecated Try to use Laravel's config() if possible. It does not support the typehint feature so it may not be possible.
+ */
+function mr_env(string $key, $default = null, $typehint = null) {
     if ( getenv($key) !== false ) {
         $v = getenv($key);
         if ( $typehint === null && $default !== null) {

--- a/app/helpers/model_lookup_helper.php
+++ b/app/helpers/model_lookup_helper.php
@@ -1,6 +1,5 @@
 <?php
-
-use munkireport\lib\Request;
+use Illuminate\Support\Facades\Http;
 
 function machine_model_lookup($serial)
 {
@@ -16,8 +15,7 @@ function machine_model_lookup($serial)
         ]
     ];
 
-    $client = new Request();
-    $result = $client->get('https://km.support.apple.com/kb/index', $options);
+    $result = Http::get('https://km.support.apple.com/kb/index', $options);
 
     if ( ! $result) {
         return 'model_lookup_failed';

--- a/app/helpers/site_helper.php
+++ b/app/helpers/site_helper.php
@@ -2,7 +2,10 @@
 
 use App\Notifications\GeneralEvent;
 use App\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Str;
@@ -27,11 +30,20 @@ $GLOBALS['alerts'] = array();
 /**
  * Add Alert
  *
- * @param string alert message
- * @param string type (danger, warning, success, info)
+ * @param string $msg alert message
+ * @param string $type type (danger, warning, success, info)
  **/
-function alert($msg, $type = "info")
+function alert(string $msg, string $type = "info"): void
 {
+    Log::channel('deprecations')
+        ->warning(
+            'This function will be deprecated in future, please use session()->flash() or similar in your modules',
+            [
+                'function' => __FUNCTION__,
+                'file' => __FILE__,
+                'line' => __LINE__,
+            ]
+        );
     $GLOBALS['alerts'][$type][] = $msg;
     request()->session()->flash($type, $msg);
 }
@@ -39,10 +51,20 @@ function alert($msg, $type = "info")
 /**
  * Add error message
  *
- * @param string message
+ * @param string $msg message
+ * @param string $i18n i18n locale key for translation of error.
  **/
-function error($msg, $i18n = '')
+function error(string $msg, $i18n = ''): void
 {
+    Log::channel('deprecations')
+        ->warning(
+            'This function will be deprecated in future, please use session()->flash() or similar in your modules',
+            [
+                'function' => __FUNCTION__,
+                'file' => __FILE__,
+                'line' => __LINE__,
+            ]
+        );
     if ($i18n) {
         $msg = sprintf('<span data-i18n="%s">%s</span>', $i18n, $msg);
     }
@@ -58,43 +80,57 @@ function error($msg, $i18n = '')
  * For Laravel 7, this function no longer handles the PDOException by displaying an error message but passes it back
  * up into the App/Exception/Handler for reporting.
  *
+ * This function is used to get a database handle from PDO, mostly from KissMvc models that use the Schema functions
+ * prior to Eloquent Capsule. It should not be used anymore.
+ *
  * @return PDO
  * @throws \PDOException
+ * @deprecated Please use the DB query builder if you need a connnection handle, or use Eloquent ORM for queries.
  */
-function getdbh()
+function getdbh(): PDO
 {
+    Log::channel('deprecations')
+        ->warning(
+            'This function will be deprecated in future, please use db query builder or eloquent.',
+            [
+                'function' => __FUNCTION__,
+                'file' => __FILE__,
+                'line' => __LINE__,
+            ]
+        );
     return DB::connection()->getPdo();
 }
 
 function has_sqlite_db($connection)
 {
-  return find_driver($connection, 'sqlite');
+    return find_driver($connection, 'sqlite');
 }
 
 function has_mysql_db($connection)
 {
-  return find_driver($connection, 'mysql');
+    return find_driver($connection, 'mysql');
 }
 
 function find_driver($connection, $driver)
 {
-  if( isset($connection['driver']) && $connection['driver'] == $driver){
-    return true;
-  }
-  return false;
+    if (isset($connection['driver']) && $connection['driver'] == $driver) {
+        return true;
+    }
+    return false;
 }
 
-function add_mysql_opts(&$conn){
-  $conn['options'] = [
-    \PDO::MYSQL_ATTR_INIT_COMMAND => sprintf('SET NAMES %s COLLATE %s', $conn['charset'], $conn['collation'])
-  ];
-  if($conn['ssl_enabled']){
-    foreach(['key', 'cert', 'ca', 'capath', 'cipher'] as $ssl_opt){
-      if($conn['ssl_'. $ssl_opt]){
-        $conn['options'][constant('PDO::MYSQL_ATTR_SSL_'.strtoupper($ssl_opt))] = $conn['ssl_'. $ssl_opt];
-      }
+function add_mysql_opts(&$conn)
+{
+    $conn['options'] = [
+        \PDO::MYSQL_ATTR_INIT_COMMAND => sprintf('SET NAMES %s COLLATE %s', $conn['charset'], $conn['collation'])
+    ];
+    if ($conn['ssl_enabled']) {
+        foreach (['key', 'cert', 'ca', 'capath', 'cipher'] as $ssl_opt) {
+            if ($conn['ssl_' . $ssl_opt]) {
+                $conn['options'][constant('PDO::MYSQL_ATTR_SSL_' . strtoupper($ssl_opt))] = $conn['ssl_' . $ssl_opt];
+            }
+        }
     }
-  }
 }
 
 /**
@@ -104,14 +140,15 @@ function add_mysql_opts(&$conn){
  * @param bool $fullurl
  * @param array $queryArray
  * @return \Illuminate\Contracts\Foundation\Application|\Illuminate\Contracts\Routing\UrlGenerator|\Illuminate\Foundation\Application|string
+ * @deprecated Please use the url() helper from the Laravel framework instead.
  */
 function mr_url($url = '', $fullurl = false, $queryArray = [])
 {
     $s = $fullurl ? conf('webhost') : '';
     $index_page = conf('index_page');
-    $s .= conf('subdirectory').($url && $index_page ? $index_page.'/' : $index_page) . ltrim($url, '/');
-    if($queryArray){
-        $s .= ($index_page ? '&amp;' : '?') .http_build_query($queryArray, '', '&amp;');
+    $s .= conf('subdirectory') . ($url && $index_page ? $index_page . '/' : $index_page) . ltrim($url, '/');
+    if ($queryArray) {
+        $s .= ($index_page ? '&amp;' : '?') . http_build_query($queryArray, '', '&amp;');
     }
 
     // There isn't a way to tell Laravel not to generate a fully qualified URL.
@@ -126,35 +163,13 @@ function mr_url($url = '', $fullurl = false, $queryArray = [])
  *
  * Take Proxy headers into account
  *
+ * @todo Still used in `laps` module.
  * @return string IP address
+ * @deprecated please use request()->getClientIp()
  */
-function getRemoteAddress()
+function getRemoteAddress(): string
 {
     return request()->getClientIp();
-}
-
-/**
- * Return a secure url
- *
- * @param string url
- * @return string secure url
- * @author
- **/
-function mr_secure_url($url = '')
-{
-    $parse_url = parse_url(mr_url($url, true));
-    $parse_url['scheme'] = 'https';
-
-    return
-         ((isset($parse_url['scheme'])) ? $parse_url['scheme'] . '://' : '')
-        .((isset($parse_url['user'])) ? $parse_url['user']
-        .((isset($parse_url['pass'])) ? ':' . $parse_url['pass'] : '') .'@' : '')
-        .((isset($parse_url['host'])) ? $parse_url['host'] : '')
-        .((isset($parse_url['port'])) ? ':' . $parse_url['port'] : '')
-        .((isset($parse_url['path'])) ? $parse_url['path'] : '')
-        .((isset($parse_url['query'])) ? '?' . $parse_url['query'] : '')
-        .((isset($parse_url['fragment'])) ? '#' . $parse_url['fragment'] : '')
-        ;
 }
 
 /**
@@ -163,7 +178,7 @@ function mr_secure_url($url = '')
  * @return integer group id
  * @author AvB
  **/
-function passphrase_to_group($passphrase)
+function passphrase_to_group($passphrase): int
 {
     $machine_group = new Machine_group;
     if ($machine_group->retrieveOne('property=? AND value=?', array('key', $passphrase))) {
@@ -174,50 +189,12 @@ function passphrase_to_group($passphrase)
 }
 
 /**
- * Convert an array of values to a key => value array
- * [a, b] is converted to [a => b]
- *
- * @return array assoc array
- * @author
- **/
-function arrayToAssoc($array)
-{
-    if(count($array) % 2){
-      throw new \Exception("Cannot convert array: array is of uneven length", 1);
-    }
-    $result = [];
-    while (count($array)) {
-        list($key, $value) = array_splice($array, 0, 2);
-        $result[$key] = $value;
-    }
-    return $result;
-}
-
-/**
- * Convert a key => value array to an array of values
- * [a => b] is converted to [a, b]
- *
- * @return array array
- * @author
- **/
-function assocToArray($array)
-{
-    $result = [];
-    foreach($array as $k => $v)
-    {
-      $result[] = $k;
-      $result[] = $v;
-    }
-    return $result;
-}
-
-/**
  * Check if a user is authorized.
  *
  * @param ?string $what The authorization name to check for, which is a key present in the config
  *                     _munkireport.authorization. Usually delete_machine, global, or archive.
- *
- * @return bool
+ * @return bool true if the user is authorized to perform the action.
+ * @deprecated Please use the available gates for RBAC 'global', 'delete_machine', 'archive' etc, or Policy for ABAC.
  */
 function authorized(?string $what = null)
 {
@@ -238,7 +215,9 @@ function authorized(?string $what = null)
             case '': // some modules are silly and pass through an empty string when they mean null
                 return true;
             default:
-                Log::warning('attempted to check authorization for action: ' . $what . ', which does not exist as a Gate');
+                Log::warning(
+                    'attempted to check authorization for action: ' . $what . ', which does not exist as a Gate'
+                );
                 return false;
         }
     } else {
@@ -251,6 +230,7 @@ function authorized(?string $what = null)
  *
  * @return boolean TRUE if authorized
  * @author
+ * @todo This has not been converted to Laravel at all, the functionality is missing.
  **/
 function authorized_for_serial(string $serial_number)
 {
@@ -272,9 +252,9 @@ function authorized_for_serial(string $serial_number)
  * @return integer computer group
  * @author AvB
  **/
-function get_machine_group($serial_number = '')
+function get_machine_group(string $serial_number = '')
 {
-    if (! isset($GLOBALS['machine_groups'][$serial_number])) {
+    if (!isset($GLOBALS['machine_groups'][$serial_number])) {
         $machine_group = \App\ReportData::select('machine_group')
             ->where('serial_number', $serial_number)
             ->pluck('machine_group')
@@ -288,9 +268,9 @@ function get_machine_group($serial_number = '')
 /**
  * Get filter for machine_group membership
  *
- * @var string optional prefix default 'WHERE'
- * @var string how to address the reportdata table - default 'reportdata'
  * @return string filter clause
+ * @var string how to address the reportdata table - default 'reportdata'
+ * @var string optional prefix default 'WHERE'
  * @author
  **/
 function get_machine_group_filter($prefix = 'WHERE', $reportdata = 'reportdata')
@@ -302,9 +282,9 @@ function get_machine_group_filter($prefix = 'WHERE', $reportdata = 'reportdata')
         $prefix = 'AND';
     }
 
-    if(is_archived_filter_on()){
+    if (is_archived_filter_on()) {
         $sql .= sprintf(' %s %s.archive_status = 0 ', $prefix, $reportdata);
-    }elseif( is_archived_only_filter_on() ){
+    } elseif (is_archived_only_filter_on()) {
         $sql .= sprintf(' %s %s.archive_status != 0 ', $prefix, $reportdata);
     }
 
@@ -324,17 +304,17 @@ function get_filtered_groups(): array
     $out = array(0);
 
     // Get filter
-    if(session()->has('filter.machine_group')){
+    if (session()->has('filter.machine_group')) {
         $out = array_diff(
             session()->get('machine_groups', []),
             session()->get('filter.machine_group')
         );
-    }else{
+    } else {
         $out = session()->get('machine_groups', []);
     }
 
     // If out is empty, signal no groups
-    if (! $out) {
+    if (!$out) {
         $out[] = -1;
     }
 
@@ -342,14 +322,14 @@ function get_filtered_groups(): array
 }
 
 // Return if session filter is not set or archived filter is not empty
-function is_archived_filter_on() {
-    return !request()->session()->has('filter.archived') ||
-        request()->session()->get('filter.archived');
+function is_archived_filter_on()
+{
+    return !request()->session()->has('filter.archived') || request()->session()->get('filter.archived');
 }
 
-function is_archived_only_filter_on() {
-    return request()->session()->has('filter.archived_only') &&
-            request()->session()->get('filter.archived_only');
+function is_archived_only_filter_on()
+{
+    return request()->session()->has('filter.archived_only') && request()->session()->get('filter.archived_only');
 }
 
 /**
@@ -366,11 +346,19 @@ function is_archived_only_filter_on() {
  *                                 in specific circumstances you don't want a notification raised. set to false if you
  *                                 *REALLY* do not want a notification raised here.
  */
-function store_event(string $serial, string $module = '', string $type = '', string $msg = 'no_message',
-    string $data = '', $raise_notification = true)
+function store_event(
+    string $serial,
+    string $module = '',
+    string $type = '',
+    string $msg = 'no_message',
+    string $data = '',
+    $raise_notification = true
+)
 {
     if (config('_munkireport.notifications.forward_events', true) && $raise_notification) {
-        Log::debug('forwarding munkireport events to notification channel(s) because notifications.forward_events = true');
+        Log::debug(
+            'forwarding munkireport events to notification channel(s) because notifications.forward_events = true'
+        );
         Notification::send(User::all(), new GeneralEvent($serial, $module, $type, $msg, $data));
     }
     Event_model::updateOrCreate(
@@ -395,7 +383,7 @@ function store_event(string $serial, string $module = '', string $type = '', str
  **/
 function delete_event($serial_number, $module = '')
 {
-    if (! authorized_for_serial($serial_number)) {
+    if (!authorized_for_serial($serial_number)) {
         return false;
     }
 
@@ -410,11 +398,11 @@ function delete_event($serial_number, $module = '')
 /**
  * Truncate a string to a maximum length
  *
- * @deprecated replaced by Str::limit
  * @param $string
  * @param int $limit
  * @param string $pad
  * @return string
+ * @deprecated replaced by Str::limit
  */
 function truncate_string($string, $limit = 100, $pad = "...")
 {
@@ -424,10 +412,10 @@ function truncate_string($string, $limit = 100, $pad = "...")
 /**
  * Backwards compatible wrapper to retrieve Modules singleton from the DI container.
  *
- * @deprecated Use Laravel Dependency Injection if possible
  * @return munkireport\lib\Modules
+ * @deprecated Use Laravel Dependency Injection if possible
  */
-function getMrModuleObj()
+function getMrModuleObj(): Modules
 {
     return app(Modules::class);
 }
@@ -435,10 +423,10 @@ function getMrModuleObj()
 /**
  * Backwards compatible wrapper to retrieve Dashboard singleton from the DI container.
  *
- * @deprecated Use Laravel Dependency Injection if possible
  * @return munkireport\lib\Dashboard
+ * @deprecated Use Laravel Dependency Injection if possible
  */
-function getDashboard()
+function getDashboard(): Dashboard
 {
     return app(Dashboard::class);
 }
@@ -448,34 +436,45 @@ function getDashboard()
  *
  * Wrapper for Laravel's `csrf_token()` helper.
  *
- * @return string
+ * @return string The current CSRF token
+ * @deprecated Use the csrf_token() helper directly if possible.
+ * @todo Cannot be removed, still in warranty admin module.
  */
-function getCSRF()
+function getCSRF(): string
 {
     return csrf_token();
 }
 
-
-function jsonError($msg = '', $status_code = 400, $exit = true)
+/**
+ * Display a JSON error.
+ *
+ * @param string $msg
+ * @param int $status_code
+ * @param bool $exit
+ * @deprecated Use native exception handling for json responses or render a blade view.
+ * @todo Still used in `localadmin` module, cannot be fully deprecated.
+ */
+function jsonError(string $msg = '', int $status_code = 400, bool $exit = true): void
 {
     jsonView(['error' => $msg], $status_code, $exit);
 }
 
 /**
- * @param string $msg The message body which will be encoded as JSON
+ * Render a JSON response (with KissMvc Framework View)
+ *
+ * @param string|array $msg The message body which will be encoded as JSON, or an array that can be json_encode()'d
  * @param int $status_code The status code that should be sent in the response body AND header
  * @param bool $exit If true, exit right after emitting response.
  * @param bool $return If true, return response object rather than emitting response (For Laravel Controllers)
  * @return \Illuminate\Http\JsonResponse|object
  */
-function jsonView($msg = '', $status_code = 200, $exit = false, $return = false)
+function jsonView($msg = '', int $status_code = 200, bool $exit = false, bool $return = false): ?JsonResponse
 {
     $response = response()->json($msg)->setStatusCode($status_code);
 
-    if(is_array($msg) && isset($msg['error']) && $msg['error'] && $status_code == 200) {
+    if (is_array($msg) && isset($msg['error']) && $msg['error'] && $status_code == 200) {
         $response = $response->setStatusCode(400);
     }
-
 
 
     // Check for error, adjust status code if necessary
@@ -491,21 +490,25 @@ function jsonView($msg = '', $status_code = 200, $exit = false, $return = false)
         $response->send();
     }
 
-    if ($exit) exit;
+    if ($exit) {
+        exit;
+    }
 
+    return null;
 }
 
 /**
  * Render and emit a KISSMVC style View.
  *
- * @depreacted You should try to use the Laravel view() helper instead, which still uses KISSMVC view for any file not ending in
+ * @deprecated You should try to use the Laravel view() helper instead, which still uses KISSMVC view for any file not ending in
  * .blade.php
  *
- * @param string $file
- * @param string $vars
- * @param string $view_path
+ * @param string $file The .php view file to render, relative to the view_path
+ * @param string|array $vars The variables to pass to the view. If empty string, no variables are passed.
+ * @param string $view_path The base view path to search for the $file parameter in. If left empty, it will be the default view path.
+ * @return void Outputs the view directly into the output buffer, nothing is returned.
  */
-function mr_view($file = '', $vars = '', $view_path = '')
+function mr_view(string $file = '', $vars = '', string $view_path = ''): void
 {
     $obj = new View();
     $obj->view($file, $vars, $view_path);
@@ -515,7 +518,7 @@ function mr_view($file = '', $vars = '', $view_path = '')
 /**
  * Render a KISSMVC style View into the output buffer then capture it as a string.
  *
- * @depreacted You should try to use the Laravel view() helper instead, which still uses KISSMVC view for any file not ending in
+ * @deprecated You should try to use the Laravel view() helper instead, which still uses KISSMVC view for any file not ending in
  * .blade.php
  *
  * @param string $file

--- a/app/lib/munkireport/BusinessUnit.php
+++ b/app/lib/munkireport/BusinessUnit.php
@@ -6,17 +6,38 @@ use munkireport\models\Business_unit as BuModel;
 use munkireport\models\Machine_group;
 use Illuminate\Support\Str;
 
+/**
+ * BusinessUnit acts as a pseudo-repository for Business Units (v5).
+ *
+ * Because v5 Business Units are not row based models (they are more like lookup tables), this class is used
+ * to assemble/disassemble them into the model updates.
+ */
 class BusinessUnit
 {
-    public function __construct() {
-    }
-
-    public function saveUnit($post_array)
+    /**
+     * Save a Business Unit (v5)
+     *
+     * The expected array might contain the following fields (decoded from form-encoded data):
+     *
+     * * name: business unit name
+     * * groupid: associated machine group id (?)
+     * * unitid: business unit id.
+     * * address: street address.
+     * * link: url
+     * * machine_groups[]: array of machine group id as string
+     * * users[], managers[], archivers[]: array of username or @group as string
+     *
+     * @param array $post_array Business unit attributes/properties
+     * @return array The updated Business unit, or error message to display.
+     */
+    public function saveUnit(array $post_array): array
     {
         $out = [];
 
         if ( ! ($unitid = $post_array['unitid'] ?? false) ) {
-            jsonError('Unitid missing');
+            return [
+                'error' => 'Unitid missing',
+            ];
         }
 
         // Check if new unit

--- a/build/config_to_env
+++ b/build/config_to_env
@@ -34,6 +34,23 @@ $obsolete_items = [
   'custom_folder',
 ];
 
+/**
+ * Convert a key => value array to an array of values
+ * [a => b] is converted to [a, b]
+ *
+ * @return array array
+ * @author
+ **/
+function assocToArray($array)
+{
+    $result = [];
+    foreach ($array as $k => $v) {
+        $result[] = $k;
+        $result[] = $v;
+    }
+    return $result;
+}
+
 function loadConfig($config_path, $what = 'conf')
 {
     if ((include $config_path) !== 1)

--- a/config/logging.php
+++ b/config/logging.php
@@ -19,6 +19,11 @@ return [
 
     'default' => env('LOG_CHANNEL', 'stack'),
 
+    // Deprecations log channel
+    // This is an optional Laravel feature for deprecation notices, which we will use to log MunkiReport deprecated
+    // module API calls. It is disabled by default as the volume will be huge.
+    'deprecations' => env('LOG_DEPRECATIONS_CHANNEL', 'null'),
+
     /*
     |--------------------------------------------------------------------------
     | Log Channels
@@ -40,6 +45,12 @@ return [
             'channels' => ['single'],
             'ignore_exceptions' => false,
         ],
+
+        // Uncomment this section to force all deprecations to be always recorded.
+//        'deprecations' => [
+//            'driver' => 'single',
+//            'path' => storage_path('logs/php-deprecation-warnings.log'),
+//        ],
 
         'single' => [
             'driver' => 'single',

--- a/docs/illuminate/v6-upgrade-guide.md
+++ b/docs/illuminate/v6-upgrade-guide.md
@@ -36,6 +36,10 @@ filter events by module or severity. This will be replaced with a user facing ev
 
 This feature was not documented anywhere and has been removed.
 
+### Deprecated API ###
+
+- `mr_secure_url()` or `secure_url()` is replaced by the Laravel `url()` helper.
+
 ## Configuration Changes ##
 
 ### Renames ###

--- a/resources/views/admin/business_units.php
+++ b/resources/views/admin/business_units.php
@@ -177,8 +177,10 @@
 				if(confirm('Are you sure?'))
 				{
 					var groupid = data.groupid;
-					var url = appUrl + '/admin/remove_machine_group';
-					$.post(url, {groupid: groupid}, function(data){
+                  var url = appUrl + '/admin/remove_machine_group/' + groupid;
+                  $.getJSON(url, function(data){
+					// var url = appUrl + '/admin/remove_machine_group';
+					// $.post(url, {groupid: groupid}, function(data){
 						if(data.success == true)
 						{
 							// Remove from MachineGroups
@@ -809,14 +811,21 @@
 			if(businessUnitsEnabled)
 			{
 				$.each(bu_data[0], function(index, value) {
-                  var row = $('<div class="row unit">')
-                    .appendTo('#bu_units')
-                    .data(value)
-                    .addClass('unitid-' + value.unitid);
+                  // var row = $('<div class="row unit">')
+                  //   .appendTo('#bu_units')
+                  //   .data(value)
+                  //   .addClass('unitid-' + value.unitid);
+                  //
+                  // var col = $('<div class="col-sm">')
+                  //   .appendTo(row)
+                  //   .each(render);
 
-                  var col = $('<div class="col-sm">')
-                    .appendTo(row)
-                    .each(render);
+                  $('#bu_units')
+                    .append($('<div>')
+                      .data(value)
+                      .addClass('col-lg-12 unit unitid-' + value.unitid)
+                      .each(render)
+                    );
 				});
 			}
 

--- a/resources/views/auth/login-old.blade.php
+++ b/resources/views/auth/login-old.blade.php
@@ -21,7 +21,7 @@
 
                             {{ config('app.name') }}
                             @if(request()->secure() === false)
-                                <a href="{{ mr_secure_url() }}"><i data-i18n="[title]auth.insecure" title="Insecure connection, switch to secure" class="text-danger fa fa-unlock-alt pull-right"></i></a>
+                                <a href="{{ url('/', [], true) }}"><i data-i18n="[title]auth.insecure" title="Insecure connection, switch to secure" class="text-danger fa fa-unlock-alt pull-right"></i></a>
                             @else
                                 <i data-i18n="[title]auth.secure" title="You're using a secure connection" class="text-success fa fa-lock pull-right"></i>
                             @endif

--- a/resources/views/error/client_error.php
+++ b/resources/views/error/client_error.php
@@ -32,7 +32,7 @@
 <?php case '426': ?>
 				
 				<span data-i18n="errors.426">You are required to visit this site using a secure connection.</span>
-				<a data-i18n="auth.go_secure" href="<?php echo mr_secure_url(); ?>">Go to secure site</a>
+				<a data-i18n="auth.go_secure" href="<?php echo url('/', [], true); ?>">Go to secure site</a>
 					
 <?php break; ?>
 <?php case '503': ?>

--- a/resources/views/errors/426.blade.php
+++ b/resources/views/errors/426.blade.php
@@ -17,7 +17,7 @@
     <div class="container mt-5">
         <div class="jumbotron">
             <h1 class="display-4" data-i18n="errors.426"><i class="fa fa-exclamation-sign"></i> You are required to visit this site using a secure connection.</h1>
-            <p class="lead"><a data-i18n="auth.go_secure" href="<?php echo mr_secure_url(); ?>">Go to secure site</a></p>
+            <p class="lead"><a data-i18n="auth.go_secure" href="{{ url('/', [], true) }}">Go to secure site</a></p>
         </div>
     </div>
 @endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -22,8 +22,8 @@
 
     <link rel="stylesheet" href="{{ asset('assets/css/font-awesome.min.css') }}">
     <link rel="stylesheet" href="{{ asset('assets/nvd3/nv.d3.min.css') }}" />
-    <link rel="stylesheet" href="{{ asset('assets/themes/' . sess_get('theme', 'Default') . '/bootstrap.min.css') }}" id="bootstrap-stylesheet" />
-    <link rel="stylesheet" href="{{ asset('assets/themes/' . sess_get('theme', 'Default') . '/nvd3.override.css') }}" id="nvd3-override-stylesheet" />
+    <link rel="stylesheet" href="{{ asset('assets/themes/' . session('theme', 'Default') . '/bootstrap.min.css') }}" id="bootstrap-stylesheet" />
+    <link rel="stylesheet" href="{{ asset('assets/themes/' . session('theme', 'Default') . '/nvd3.override.css') }}" id="nvd3-override-stylesheet" />
     <link rel="stylesheet" href="{{ asset('assets/css/style.css') }}" />
 
     <!-- Head scripts -->

--- a/resources/views/layouts/mr.blade.php
+++ b/resources/views/layouts/mr.blade.php
@@ -87,7 +87,7 @@
 
 @auth
 @php
-$modules = getMrModuleObj()->loadInfo();
+$modules = app(\munkireport\lib\Modules::class)->loadInfo();
 $dashboard = getDashboard()->loadAll();
 $page = url()->current();
 @endphp
@@ -161,7 +161,7 @@ $page = url()->current();
                         @foreach(scandir(conf('view_path') . 'admin') as $list_url)
                             @if(strpos($list_url, 'php'))
                             @php $page_url = strtok($list_url, '.'); @endphp
-                                <a class="dropdown-item {{ Route::is($page_url) ? " active" : "" }}" href="{{ url($page_url) }}" data-i18n="nav.admin.{{ strtok($list_url, '.') }}"></a>
+                                <a class="dropdown-item {{ Route::is($page_url) ? " active" : "" }}" href="{{ url('/admin/show/' . $page_url) }}" data-i18n="nav.admin.{{ strtok($list_url, '.') }}"></a>
                             @endif
                         @endforeach
                         @foreach($modules->getDropdownData('admin_pages', 'module', $page) as $item)

--- a/resources/views/layouts/mr.blade.php
+++ b/resources/views/layouts/mr.blade.php
@@ -22,8 +22,8 @@
 
     <link rel="stylesheet" href="{{ asset('assets/css/font-awesome.min.css') }}">
     <link rel="stylesheet" href="{{ asset('assets/nvd3/nv.d3.min.css') }}" />
-    <link rel="stylesheet" href="{{ asset('assets/themes/' . sess_get('theme', 'Default') . '/bootstrap.min.css') }}" id="bootstrap-stylesheet" />
-    <link rel="stylesheet" href="{{ asset('assets/themes/' . sess_get('theme', 'Default') . '/nvd3.override.css') }}" id="nvd3-override-stylesheet" />
+    <link rel="stylesheet" href="{{ asset('assets/themes/' . session('theme', 'Default') . '/bootstrap.min.css') }}" id="bootstrap-stylesheet" />
+    <link rel="stylesheet" href="{{ asset('assets/themes/' . session('theme', 'Default') . '/nvd3.override.css') }}" id="nvd3-override-stylesheet" />
     <link rel="stylesheet" href="{{ asset('assets/css/style.css') }}" />
 
     <!-- Head scripts -->

--- a/resources/views/layouts/spa.blade.php
+++ b/resources/views/layouts/spa.blade.php
@@ -43,7 +43,7 @@
 <body class="mr-spa-layout" style="padding-top: 56px;">
 @auth
 @php
-$modules = getMrModuleObj()->loadInfo();
+$modules = app(\munkireport\lib\Modules::class)->loadInfo();
 $dashboard = getDashboard()->loadAll();
 $page = url()->current();
 @endphp

--- a/resources/views/layouts/spa.blade.php
+++ b/resources/views/layouts/spa.blade.php
@@ -21,7 +21,7 @@
     <meta name="theme-color" content="#5d5858">
 
     <link rel="stylesheet" href="{{ asset('assets/css/font-awesome.min.css') }}">
-    <link rel="stylesheet" href="{{ asset('assets/themes/' . sess_get('theme', 'Default') . '/bootstrap.min.css') }}" id="bootstrap-stylesheet" />
+    <link rel="stylesheet" href="{{ asset('assets/themes/' . session('theme', 'Default') . '/bootstrap.min.css') }}" id="bootstrap-stylesheet" />
 
     <!-- munkireport.custom_css -->
     @if (config('_munkireport.custom_css'))

--- a/resources/views/partials/head.php
+++ b/resources/views/partials/head.php
@@ -22,8 +22,8 @@
 
     <link rel="stylesheet" href="<?php echo asset('assets/css/font-awesome.min.css'); ?>">
 	<link rel="stylesheet" href="<?php echo asset('assets/nvd3/nv.d3.min.css'); ?>" />
-	<link rel="stylesheet" href="<?php echo asset('assets/themes/' . sess_get('theme', 'Default') . '/bootstrap.min.css'); ?>" id="bootstrap-stylesheet" />
-	<link rel="stylesheet" href="<?php echo asset('assets/themes/' . sess_get('theme', 'Default') . '/nvd3.override.css'); ?>" id="nvd3-override-stylesheet" />
+	<link rel="stylesheet" href="<?php echo asset('assets/themes/' . session('theme', 'Default') . '/bootstrap.min.css'); ?>" id="bootstrap-stylesheet" />
+	<link rel="stylesheet" href="<?php echo asset('assets/themes/' . session('theme', 'Default') . '/nvd3.override.css'); ?>" id="nvd3-override-stylesheet" />
 	<link rel="stylesheet" href="<?php echo asset('assets/css/style.css'); ?>" />
 
     <!-- Head scripts -->

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -21,7 +21,7 @@ Route::middleware(['auth', 'can:global'])->group(function () {
     Route::post('/admin/save_business_unit', 'AdminController@save_business_unit');
     Route::post('/admin/remove_business_unit', 'AdminController@remove_business_unit');
     Route::post('/admin/save_machine_group', 'AdminController@save_machine_group');
-    Route::post('/admin/remove_machine_group', 'AdminController@remove_machine_group');
+    Route::get('/admin/remove_machine_group/{groupid?}', 'AdminController@remove_machine_group');
     Route::get('/admin/show/{which}', 'AdminController@show');
 
     // TODO: Deprecated /system/show for /system, add redirect

--- a/tests/Unit/helpers/ModelLookupHelperTest.php
+++ b/tests/Unit/helpers/ModelLookupHelperTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Unit\helpers;
+
+use PHPUnit\Framework\TestCase;
+
+class ModelLookupHelperTest extends TestCase
+{
+    protected $serial = '';
+
+    public function testMachineModelLookup()
+    {
+        require_once(__DIR__ . '/../../../app/helpers/model_lookup_helper.php');
+
+        $result = \machine_model_lookup($this->serial);
+        $this->assertNotEmpty($result);
+    }
+}


### PR DESCRIPTION
Add deprecation logging to deprecated API's with opt-in log file
Lots of docblocks explaining deprecated API's and replacements
Attempt to remove deprecated API usage from core.
Go back to legacy implementation of Business Units as the new one is not ready.
Remove several functions from v5 helpers library.
