### PR TITLE
Updated method to get CPU arch to get it from the full uname string

### DIFF
--- a/public/assets/client_installer/payload/usr/local/munkireport/munkireport-runner
+++ b/public/assets/client_installer/payload/usr/local/munkireport/munkireport-runner
@@ -28,7 +28,7 @@ def main():
     hardware_info = reportcommon.get_hardware_info()
     hardware_info['computer_name'] = reportcommon.get_computername()
     hardware_info['cpu'] = reportcommon.get_cpuinfo()
-    hardware_info['cpu_arch'] = reportcommon.get_cpuarch()
+    hardware_info['cpu_arch'] = ''.join(re.findall(r'RELEASE_([iA-Z1-9]+)(_\d+)?', os.uname()[3])[0]).lower()
     hardware_info['hostname'] = os.uname()[1]
     hardware_info['os_version'] = \
         reportcommon.getOsVersion(only_major_minor=False)


### PR DESCRIPTION
This PR changes how the main runner grabs the CPU arch, as using `os.uname()[4]` is unreliable when used with Rosetta 2 on Apple Silicon.

Instead, we just search the uname string provided by `os.uname()[3]`, and lowercase it to match existing data.

I have tested this with the arm64 and x86_64 strings, but I don't have a physical machine to test i386 with 😅