### PR TITLE
Set permissions on cache directory

### DIFF
--- a/app/views/install/install_script.php
+++ b/app/views/install/install_script.php
@@ -137,6 +137,7 @@ echo "# Preparing ${MUNKIPATH}"
 /bin/mkdir -p "${MUNKIPATH}munkilib"
 /bin/mkdir -p "${MUNKIPATH}scripts/cache"
 /bin/mkdir -p "${INSTALLROOT}/Library/MunkiReport/Logs"
+/bin/chmod 600 "${MUNKIPATH}scripts/cache/" # drw------- root wheel
 
 # Create preflight.d symlinks
 /bin/rm -rf "${MUNKIPATH}preflight.d" && /bin/ln -s "scripts" "${MUNKIPATH}preflight.d"
@@ -289,6 +290,9 @@ if [[ "\$3" == "/" ]]; then
 		echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 		echo " "
 	fi
+
+	# Set permissions on cache directory
+	/bin/chmod 600 /usr/local/munkireport/scripts/cache/ # drw------- root wheel
 
 else
 	TARGET="\$3"


### PR DESCRIPTION
Sets permissions on cache directory to 600 `drw------- root wheel` to prevent non-admin users from accessing potentially sensitive cache files. 