### PR TITLE
Remove hyperlinks to kissmvc.com

### DIFF
--- a/app/controllers/Module.php
+++ b/app/controllers/Module.php
@@ -85,7 +85,7 @@ class Module extends Controller
     public function requestNotFound($msg = '')
     {
         header("HTTP/1.0 404 Not Found");
-        die('<html><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>'.$msg.'<p>The requested URL was not found on this server.</p><p>Please go <a href="javascript: history.back( 1 )">back</a> and try again.</p><hr /><p>Powered By: <a href="http://kissmvc.com">KISSMVC</a></p></body></html>');
+        die('<html><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>'.$msg.'<p>The requested URL was not found on this server.</p><p>Please go <a href="javascript: history.back( 1 )">back</a> and try again.</p><hr /></body></html>');
     }
 
     public function requestForbidden($msg = '')

--- a/system/kissmvc_core.php
+++ b/system/kissmvc_core.php
@@ -225,7 +225,7 @@ abstract class KISS_Engine
     public function requestNotFound($msg = '')
     {
         header("HTTP/1.0 404 Not Found");
-        die('<html><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>'.$msg.'<p>The requested URL was not found on this server.</p><p>Please go <a href="javascript: history.back( 1 )">back</a> and try again.</p><hr /><p>Powered By: <a href="http://kissmvc.com">KISSMVC</a></p></body></html>');
+        die('<html><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>'.$msg.'<p>The requested URL was not found on this server.</p><p>Please go <a href="javascript: history.back( 1 )">back</a> and try again.</p><hr /></body></html>');
     }
 }
 


### PR DESCRIPTION
Removes the hyperlink to `kissmvc.com` on HTTP 404 pages generated by MunkiReport. Resolves issue #1540 