### PR TITLE
Replace deprecated mailing lists with Slack channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,21 +35,20 @@ System Requirements
 
 * a Modern webbrowser
 
-Mailing lists
+Support
 ---
 
-For questions about using MunkiReport or setting up MunkiReport, you can use:
-
-https://groups.google.com/group/munkireport
-
-For developers who want to contribute to the project:
-
-https://groups.google.com/group/munkireport-dev
-
-For security related issues, please use the private mailinglist:
+For security-related issues, please use the private mailing list:
 
 https://groups.google.com/group/munkireport-security
 
+Otherwise, the MunkiReport community can be found on the Mac Admins Slack:
+
+https://www.macadmins.org
+
+For questions about using MunkiReport or setting up MunkiReport, join us in the #munkireport channel.
+
+For developers who want to contribute to the project, join us in the #munkireport-dev channel.
 
 Contributing
 ---
@@ -79,5 +78,3 @@ MunkiReport makes use of these fine software packages:
 * [Font Awesome](http://fortawesome.github.io/Font-Awesome/) for icons
 * [adLDAP](https://github.com/Adldap2/Adldap2) for authenticating against AD
 * [i18next](http://i18next.com) js library for localization
-
-


### PR DESCRIPTION
The mailing lists for support and development have been replaced by channels on the Mac Admins Slack, so I changed the language for those seeking support. The security mailing list is still active, however, so I made that more prominent.

I also reduced the newlines at the end of the README from 3 lines to 1, since I was already editing the file.