### PR TITLE
Add deny-if-empty feature to ENV authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,7 @@ SITENAME="MunkiReport"
 #
 # AUTH_METHODS can be one of
 # - "NOAUTH": No authentication
+# - "ENV": Environment variable (without password) Authentication
 # - "LOCAL" : Local Users defined as .yml in the "users" folder
 # - "LDAP": LDAP Authentication
 # - "AD": Active Directory Authentication
@@ -86,12 +87,25 @@ SITENAME="MunkiReport"
 #
 # Authentication providers are checked in this order:
 # - Noauth
+# - Environment variable
 # - Generated local user
 # - LDAP
 # - Active Directory
 
 
 AUTH_METHODS="NOAUTH"
+
+# ENVIRONMENT VARIABLE AUTHENTICATION
+# -------------------------------
+#
+# Read the authenticated username from the
+# given server environment variable. Useful
+# for handling authentication via a reverse
+# proxy (i.e. HTTP header, forward auth, Kerberos)
+AUTH_ENV_USER_VAR="REMOTE_USER"
+# Set to TRUE to fail authentication if the
+# above-named variable is empty or missing.
+AUTH_ENV_DENY_EMPTY=FALSE
 
 # ACTIVE DIRECTORY AUTHENTICATION
 # -------------------------------

--- a/app/config/auth/env.php
+++ b/app/config/auth/env.php
@@ -1,5 +1,6 @@
 <?php
 
 return [
-    'env_user_var'            => 'REMOTE_USER',
+    'env_user_var'            => env('AUTH_ENV_USER_VAR', 'REMOTE_USER'),
+    'env_user_deny_empty'     => env('AUTH_ENV_DENY_EMPTY', false),
 ];

--- a/app/lib/munkireport/AuthEnv.php
+++ b/app/lib/munkireport/AuthEnv.php
@@ -4,7 +4,7 @@ namespace munkireport\lib;
 
 class AuthEnv extends AbstractAuth
 {
-    private $config;
+    private $config, $login, $authStatus;
 
     public function __construct($config)
     {
@@ -13,6 +13,19 @@ class AuthEnv extends AbstractAuth
     
     public function login($login, $password)
     {
+        $this->login = getenv($this->config['env_user_var']);
+
+        if ($this->config['env_user_deny_empty'] && empty($this->login)) {
+            if ($this->login === '') {
+                $this->authStatus = 'unauthorized';
+            } elseif ($this->login === false) {
+                $this->authStatus = 'failed';
+            }
+
+            return false;
+        }
+
+        $this->authStatus = 'success';
         return true;
     }
     
@@ -23,12 +36,12 @@ class AuthEnv extends AbstractAuth
 
     public function getAuthStatus()
     {
-        return 'success';
+        return $this->authStatus;
     }
     
     public function getUser()
     {
-        return getenv($this->config['env_user_var']);
+        return $this->login;
     }
 
     public function getGroups()

--- a/app/lib/munkireport/AuthLDAP.php
+++ b/app/lib/munkireport/AuthLDAP.php
@@ -4,7 +4,7 @@ namespace munkireport\lib;
 
 class AuthLDAP extends AbstractAuth
 {
-    private $config, $groups, $login, $auth_status;
+    private $config, $groups, $login, $authStatus;
 
     public function __construct($config)
     {

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -59,5 +59,7 @@ Munkireport will **not** set the passphrase on the client through the install sc
 - `SITENAME`: The site name which will appear in the title bar of your browser, Default: `MunkiReport`.
 - `AUTH_METHODS`: A comma separated list of supported Authentication methods. Any combination of:
     - `NOAUTH`: No authentication required
+    - `ENV`: Environment variable Authentication
+    - `LOCAL` : Local Users defined as .yml in the `users` folder
     - `LDAP`: LDAP Authentication
     - `AD`: Active Directory Authentication


### PR DESCRIPTION
When using `ENV` environment variable authentication, add option to deny authentication if the environment variable (default `REMOTE_USER`) is empty or missing from the environment. When a web server defaults to `REMOTE_USER` being empty for unauthenticated sessions, this prevents a user with "blank username" from being logged into MunkiReport. This also allows for fallback to another authentication method; for example:
1. Try `ENV` auth to check if `REMOTE_USER` is set for users accessing MunkiReport via Tailscale Serve, which can set an authenticated username request header.
2. Fall back to `LDAP` or `SAML` auth if users are accessing MR not via Tailscale.

*Notes*:
* Disabled by default, so the previous `ENV` behavior is preserved, and this is not a breaking change
* A present but blank environment variable returns `unauthorized`, and a missing environment variable returns `failed`; this would aid in debugging.