### PR TITLE
Add AUTH_SAML_SET_PROXY_VARS env

### DIFF
--- a/app/config/auth/saml.php
+++ b/app/config/auth/saml.php
@@ -25,6 +25,7 @@ return [
   ],
   'disable_sso'       => env('AUTH_SAML_DISABLE_SSO', false),
   'debug'             => env('AUTH_SAML_DEBUG', false),
+  'set_proxy_vars'    => env('AUTH_SAML_SET_PROXY_VARS', false),
   'security'          => [
     'nameIdEncrypted'            => env('AUTH_SAML_SECURITY_NAME_ID_ENCRYPTED', false),
     'authnRequestsSigned'        => env('AUTH_SAML_SECURITY_AUTHN_REQUESTS_SIGNED', false),

--- a/app/lib/munkireport/AuthSaml.php
+++ b/app/lib/munkireport/AuthSaml.php
@@ -4,6 +4,7 @@ namespace munkireport\lib;
 use \OneLogin\Saml2\Auth as OneLogin_Saml2_Auth;
 use \OneLogin\Saml2\Settings as OneLogin_Saml2_Settings;
 use \OneLogin\Saml2\Error as OneLogin_Saml2_Error;
+use \OneLogin\Saml2\Utils as OneLogin_Saml2_Utils;
 use \Exception, \View;
 use \Illuminate\Filesystem\Filesystem;
 
@@ -108,6 +109,7 @@ class AuthSaml extends AbstractAuth
     // Initiate Single Sign On
     private function sso()
     {
+        OneLogin_Saml2_Utils::setProxyVars(true);
         $auth = new OneLogin_Saml2_Auth($this->config);
         $auth->login(
             $returnTo = null,
@@ -120,6 +122,7 @@ class AuthSaml extends AbstractAuth
     // Retrieve Data from IDP
     private function acs()
     {
+        OneLogin_Saml2_Utils::setProxyVars(true);
         $auth = new OneLogin_Saml2_Auth($this->config);
         if (isset($_SESSION) && isset($_SESSION['AuthNRequestID'])) {
             $requestID = $_SESSION['AuthNRequestID'];
@@ -175,6 +178,7 @@ class AuthSaml extends AbstractAuth
             return;
         }
 
+        OneLogin_Saml2_Utils::setProxyVars(true);
         $auth = new OneLogin_Saml2_Auth($this->config);
 
         $returnTo = url('auth/saml/sls');
@@ -199,6 +203,7 @@ class AuthSaml extends AbstractAuth
 
     private function sls()
     {
+        OneLogin_Saml2_Utils::setProxyVars(true);
         $auth = new OneLogin_Saml2_Auth($this->config);
 
         if (isset($_SESSION) && isset($_SESSION['LogoutRequestID'])) {

--- a/app/lib/munkireport/AuthSaml.php
+++ b/app/lib/munkireport/AuthSaml.php
@@ -109,7 +109,9 @@ class AuthSaml extends AbstractAuth
     // Initiate Single Sign On
     private function sso()
     {
-        OneLogin_Saml2_Utils::setProxyVars(true);
+        if ($this->config['set_proxy_vars']) {
+            OneLogin_Saml2_Utils::setProxyVars(true);
+        }
         $auth = new OneLogin_Saml2_Auth($this->config);
         $auth->login(
             $returnTo = null,
@@ -122,7 +124,9 @@ class AuthSaml extends AbstractAuth
     // Retrieve Data from IDP
     private function acs()
     {
-        OneLogin_Saml2_Utils::setProxyVars(true);
+        if ($this->config['set_proxy_vars']) {
+            OneLogin_Saml2_Utils::setProxyVars(true);
+        }
         $auth = new OneLogin_Saml2_Auth($this->config);
         if (isset($_SESSION) && isset($_SESSION['AuthNRequestID'])) {
             $requestID = $_SESSION['AuthNRequestID'];
@@ -178,7 +182,9 @@ class AuthSaml extends AbstractAuth
             return;
         }
 
-        OneLogin_Saml2_Utils::setProxyVars(true);
+        if ($this->config['set_proxy_vars']) {
+            OneLogin_Saml2_Utils::setProxyVars(true);
+        }
         $auth = new OneLogin_Saml2_Auth($this->config);
 
         $returnTo = url('auth/saml/sls');
@@ -203,7 +209,9 @@ class AuthSaml extends AbstractAuth
 
     private function sls()
     {
-        OneLogin_Saml2_Utils::setProxyVars(true);
+        if ($this->config['set_proxy_vars']) {
+            OneLogin_Saml2_Utils::setProxyVars(true);
+        }
         $auth = new OneLogin_Saml2_Auth($this->config);
 
         if (isset($_SESSION) && isset($_SESSION['LogoutRequestID'])) {


### PR DESCRIPTION
In some setups when running MunkiReport behind a TLS terminating load balancer, there will be a discrepancy between the internal and external URL that causes SAML to fail. With `AUTH_SAML_DEBUG` enabled the error will look something like:

> The response was received at https://munkireport.foo.bar:8080/auth/saml/acs instead of https://munkireport.foo.bar/auth/saml/acs
> 
> invalid_response
> 
> Not authenticated

This PR fixes it by adding a new config variable `AUTH_SAML_SET_PROXY_VARS` that when enabled calls `OneLogin_Saml2_Utils::setProxyVars(true)` before every creation of a `OneLogin_Saml2_Auth` object.
